### PR TITLE
Add InSim/OutSim telemetry radar prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
 # LFS-Ayats
-LFS telemetry.
+
+Prototype telemetry radar for Live for Speed (LFS).  The project connects to
+InSim for control commands, listens to OutSim telemetry, and renders a simple
+ASCII radar that mirrors the original prototype behaviour.
+
+## Requirements
+
+* Python 3.10 or newer
+
+No third-party dependencies are required; only the Python standard library is
+used.
+
+## Configuration
+
+All runtime settings are stored in [`config.json`](config.json):
+
+```json
+{
+  "insim": {
+    "host": "127.0.0.1",
+    "port": 29999,
+    "admin_password": "",
+    "interval_ms": 100
+  },
+  "outsim": {
+    "port": 30000,
+    "update_hz": 60
+  }
+}
+```
+
+* **`insim.host` / `insim.port`** – address of the LFS InSim server.
+* **`insim.admin_password`** – optional admin password if your server requires
+  authentication.
+* **`insim.interval_ms`** – desired update interval for InSim packets.
+* **`outsim.port`** – UDP port the game broadcasts OutSim packets to (configure
+  this in `cfg.txt` within LFS).
+* **`outsim.update_hz`** – documentation value for your preferred update rate;
+  currently informational only for the prototype.
+
+Adjust the values to match your LFS setup before running the program.
+
+## Running the radar
+
+1. Ensure LFS is configured to send OutSim packets to the machine running this
+   script and that InSim is enabled.
+2. Start the prototype:
+
+   ```bash
+   python main.py
+   ```
+
+   The script connects to InSim, waits for OutSim telemetry, and continuously
+   prints the ASCII radar to the terminal. Press `Ctrl+C` to exit.
+
+## Development notes
+
+The telemetry helpers live in the `src/` package:
+
+* [`src/insim_client.py`](src/insim_client.py) – minimal TCP wrapper for InSim.
+* [`src/outsim_client.py`](src/outsim_client.py) – UDP listener parsing OutSim
+  frames.
+* [`src/radar.py`](src/radar.py) – ASCII renderer for OutSim positions.
+
+These modules are intentionally small and can be extended with additional
+functionality from the InSim/OutSim specifications as needed.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,12 @@
+{
+  "insim": {
+    "host": "127.0.0.1",
+    "port": 29999,
+    "admin_password": "",
+    "interval_ms": 100
+  },
+  "outsim": {
+    "port": 30000,
+    "update_hz": 60
+  }
+}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,50 @@
+"""Entry point for the telemetry radar prototype."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+from src.insim_client import InSimClient, InSimConfig
+from src.outsim_client import OutSimClient
+from src.radar import RadarRenderer
+
+logger = logging.getLogger(__name__)
+
+
+def load_config(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(name)s: %(message)s")
+
+    config_path = Path(__file__).resolve().parent / "config.json"
+    config = load_config(config_path)
+
+    insim_cfg_raw = config.get("insim", {})
+    outsim_cfg_raw = config.get("outsim", {})
+
+    insim_cfg = InSimConfig(
+        host=insim_cfg_raw.get("host", "127.0.0.1"),
+        port=int(insim_cfg_raw.get("port", 29999)),
+        admin_password=insim_cfg_raw.get("admin_password", ""),
+        interval_ms=int(insim_cfg_raw.get("interval_ms", 100)),
+    )
+
+    outsim_port = int(outsim_cfg_raw.get("port", 30000))
+    radar = RadarRenderer()
+
+    try:
+        with InSimClient(insim_cfg) as insim, OutSimClient(outsim_port) as outsim:
+            logger.info("Telemetry clients initialised; awaiting OutSim frames")
+            for frame in outsim.frames():
+                radar.draw(frame)
+    except KeyboardInterrupt:
+        logger.info("Interrupted by user, shutting down")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Helper package for the LFS telemetry prototype."""

--- a/src/insim_client.py
+++ b/src/insim_client.py
@@ -1,0 +1,133 @@
+"""Client utilities for working with the Live for Speed InSim interface."""
+from __future__ import annotations
+
+import logging
+import socket
+import struct
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+# -- InSim protocol helpers -------------------------------------------------
+
+# InSim packet and flag constants.  Only the few flags that are relevant for
+# enabling multiplayer-safe telemetry are included – additional flags can be
+# added in the future as the prototype grows.
+ISP_ISI = 1
+ISP_MST = 11
+
+ISF_MCI = 1 << 0  # receive multi car info packets
+ISF_CON = 1 << 1  # receive contact packets
+ISF_OBH = 1 << 2  # receive object hit packets
+
+
+@dataclass
+class InSimConfig:
+    """Configuration values required to establish an InSim connection."""
+
+    host: str
+    port: int
+    admin_password: str = ""
+    interval_ms: int = 100
+    timeout: Optional[float] = 5.0
+
+
+class InSimClient:
+    """Minimal TCP client for the Live for Speed InSim protocol."""
+
+    def __init__(self, config: InSimConfig) -> None:
+        self._config = config
+        self._sock: Optional[socket.socket] = None
+
+    # -- socket lifecycle --------------------------------------------------
+    def connect(self) -> None:
+        """Open a TCP socket, connect to the server and send ``IS_ISI``."""
+
+        if self._sock is not None:
+            logger.debug("Reconnecting: closing existing socket")
+            self.close()
+
+        logger.info("Connecting to InSim at %s:%s", self._config.host, self._config.port)
+        sock = socket.create_connection(
+            (self._config.host, self._config.port), timeout=self._config.timeout
+        )
+        self._sock = sock
+
+        size = 44
+        reqi = 0
+        udp_port = 0  # we are not using a UDP connection for InSim packets here
+        flags = ISF_MCI | ISF_CON | ISF_OBH
+        sp0 = 0
+        prefix = ord("/")
+        interval = max(1, self._config.interval_ms)
+        admin = self._config.admin_password.encode("ascii", errors="ignore")[:16]
+        admin = admin.ljust(16, b"\x00")
+        iname = b"LFS-Ayats Prototype"
+        iname = iname[:16].ljust(16, b"\x00")
+
+        packet = struct.pack(
+            "<BBBBHHBBH16s16s",
+            size,
+            ISP_ISI,
+            reqi,
+            0,
+            udp_port,
+            flags,
+            sp0,
+            prefix,
+            interval,
+            admin,
+            iname,
+        )
+        logger.debug("Sending IS_ISI initialisation packet: %s", packet)
+        sock.sendall(packet)
+
+    def close(self) -> None:
+        """Close the underlying TCP socket."""
+
+        if self._sock is not None:
+            try:
+                self._sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            finally:
+                self._sock.close()
+                self._sock = None
+
+    # -- messaging ---------------------------------------------------------
+    def send_command(self, message: str, req_id: int = 0) -> None:
+        """Send a plain text command via an ``IS_MST`` packet."""
+
+        if not message:
+            raise ValueError("Command message must not be empty")
+        if self._sock is None:
+            raise RuntimeError("InSim socket is not connected")
+
+        payload = message.encode("ascii", errors="ignore")[:63]
+        payload = payload.ljust(64, b"\x00")
+        packet = struct.pack(
+            "<BBBBBBBB64s",
+            68,  # packet size
+            ISP_MST,
+            req_id & 0xFF,
+            0,
+            0,
+            0,
+            0,
+            0,
+            payload,
+        )
+        logger.debug("Sending IS_MST command packet: %s", packet)
+        self._sock.sendall(packet)
+
+    def __enter__(self) -> "InSimClient":
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        self.close()
+
+
+__all__ = ["InSimClient", "InSimConfig"]

--- a/src/outsim_client.py
+++ b/src/outsim_client.py
@@ -1,0 +1,113 @@
+"""OutSim UDP client utilities."""
+from __future__ import annotations
+
+import logging
+import socket
+import struct
+from dataclasses import dataclass
+from typing import Iterable, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# The classic OutSim packet layout used by the LFS public demo and retail
+# releases.  The message is always little endian.
+_OUTSIM_STRUCT = struct.Struct("<I3f3f3f3f3f")
+
+
+@dataclass
+class OutSimFrame:
+    """A parsed OutSim telemetry frame."""
+
+    time_ms: int
+    ang_vel: Tuple[float, float, float]
+    orientation: Tuple[float, float, float]  # heading, pitch, roll
+    acceleration: Tuple[float, float, float]
+    velocity: Tuple[float, float, float]
+    position: Tuple[float, float, float]
+
+    @classmethod
+    def from_packet(cls, packet: bytes) -> "OutSimFrame":
+        if len(packet) < _OUTSIM_STRUCT.size:
+            raise ValueError(
+                f"OutSim packet too small: expected {_OUTSIM_STRUCT.size} bytes, got {len(packet)}"
+            )
+
+        (time_ms, *values) = _OUTSIM_STRUCT.unpack_from(packet)
+        ang_vel = tuple(values[0:3])  # type: ignore[assignment]
+        orientation = tuple(values[3:6])  # heading, pitch, roll
+        acceleration = tuple(values[6:9])
+        velocity = tuple(values[9:12])
+        position = tuple(values[12:15])
+        return cls(
+            time_ms=time_ms,
+            ang_vel=ang_vel,  # type: ignore[arg-type]
+            orientation=orientation,  # type: ignore[arg-type]
+            acceleration=acceleration,  # type: ignore[arg-type]
+            velocity=velocity,  # type: ignore[arg-type]
+            position=position,  # type: ignore[arg-type]
+        )
+
+    @property
+    def speed(self) -> float:
+        vx, vy, vz = self.velocity
+        return (vx * vx + vy * vy + vz * vz) ** 0.5
+
+
+class OutSimClient:
+    """UDP client that yields :class:`OutSimFrame` objects."""
+
+    def __init__(self, port: int, host: str = "0.0.0.0", buffer_size: int = 256, timeout: Optional[float] = None) -> None:
+        self._host = host
+        self._port = port
+        self._buffer_size = buffer_size
+        self._timeout = timeout
+        self._sock: Optional[socket.socket] = None
+
+    def start(self) -> None:
+        if self._sock is not None:
+            logger.debug("Rebinding OutSim socket")
+            self.close()
+
+        logger.info("Binding OutSim UDP listener on %s:%s", self._host, self._port)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind((self._host, self._port))
+        if self._timeout is not None:
+            sock.settimeout(self._timeout)
+        self._sock = sock
+
+    def frames(self) -> Iterable[OutSimFrame]:
+        if self._sock is None:
+            raise RuntimeError("OutSim socket has not been started")
+
+        while True:
+            try:
+                data, addr = self._sock.recvfrom(self._buffer_size)
+            except socket.timeout:
+                logger.debug("OutSim socket timed out waiting for data")
+                continue
+            except OSError as exc:
+                logger.debug("OutSim socket error: %s", exc)
+                raise
+
+            logger.debug("Received OutSim packet from %s", addr)
+            try:
+                yield OutSimFrame.from_packet(data)
+            except ValueError as exc:
+                logger.warning("Discarding invalid OutSim packet: %s", exc)
+
+    def close(self) -> None:
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            finally:
+                self._sock = None
+
+    def __enter__(self) -> "OutSimClient":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        self.close()
+
+
+__all__ = ["OutSimClient", "OutSimFrame"]

--- a/src/radar.py
+++ b/src/radar.py
@@ -1,0 +1,52 @@
+"""ASCII radar visualisation for OutSim telemetry."""
+from __future__ import annotations
+
+import math
+import sys
+from typing import List, TextIO
+
+from .outsim_client import OutSimFrame
+
+
+class RadarRenderer:
+    """Render a top down radar using a square ASCII grid."""
+
+    def __init__(self, grid_size: int = 21, radius_m: float = 50.0) -> None:
+        if grid_size % 2 == 0:
+            raise ValueError("grid_size must be an odd number so that a centre cell exists")
+        self._grid_size = grid_size
+        self._half = grid_size // 2
+        self._scale = radius_m / self._half if self._half else 1.0
+
+    def render(self, frame: OutSimFrame) -> str:
+        grid: List[List[str]] = [["."] * self._grid_size for _ in range(self._grid_size)]
+        grid[self._half][self._half] = "O"  # origin / player car
+
+        x, y, _ = frame.position
+        col = self._half + int(round(x / self._scale))
+        row = self._half - int(round(y / self._scale))
+        if 0 <= row < self._grid_size and 0 <= col < self._grid_size:
+            grid[row][col] = "X"
+
+        lines = [
+            "Radar view (O = origin, X = current OutSim position)",
+            f"Time: {frame.time_ms / 1000:.2f}s  Speed: {frame.speed * 3.6:.1f} km/h",
+            f"Pos: x={x:7.2f}m y={y:7.2f}m z={frame.position[2]:7.2f}m",
+            f"Orientation: heading={math.degrees(frame.orientation[0]):6.1f}° "
+            f"pitch={math.degrees(frame.orientation[1]):6.1f}° roll={math.degrees(frame.orientation[2]):6.1f}°",
+            "",
+        ]
+        for row_cells in grid:
+            lines.append(" ".join(row_cells))
+        return "\n".join(lines)
+
+    def draw(self, frame: OutSimFrame, stream: TextIO = sys.stdout) -> None:
+        """Clear the console and draw the radar for ``frame``."""
+
+        stream.write("\x1b[2J\x1b[H")
+        stream.write(self.render(frame))
+        stream.write("\n")
+        stream.flush()
+
+
+__all__ = ["RadarRenderer"]


### PR DESCRIPTION
## Summary
- add a repository level `config.json` describing InSim/OutSim connection defaults
- implement TCP/UDP client wrappers and an ASCII radar renderer for telemetry frames
- wire up `main.py` to drive the prototype and document setup and usage in the README

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68f399005ff8832fbc13f6690e7087cf