### PR TITLE
Compute yaw/pitch/roll from OutSim heading vector

### DIFF
--- a/src/radar.py
+++ b/src/radar.py
@@ -1,7 +1,6 @@
 """ASCII radar visualisation for OutSim telemetry."""
 from __future__ import annotations
 
-import math
 import sys
 from typing import List, TextIO
 
@@ -28,12 +27,12 @@ class RadarRenderer:
         if 0 <= row < self._grid_size and 0 <= col < self._grid_size:
             grid[row][col] = "X"
 
+        yaw_deg, pitch_deg, roll_deg = frame.yaw_pitch_roll_degrees
         lines = [
             "Radar view (O = origin, X = current OutSim position)",
             f"Time: {frame.time_ms / 1000:.2f}s  Speed: {frame.speed * 3.6:.1f} km/h",
             f"Pos: x={x:7.2f}m y={y:7.2f}m z={frame.position[2]:7.2f}m",
-            f"Orientation: heading={math.degrees(frame.orientation[0]):6.1f}° "
-            f"pitch={math.degrees(frame.orientation[1]):6.1f}° roll={math.degrees(frame.orientation[2]):6.1f}°",
+            f"Orientation: yaw={yaw_deg:6.1f}° pitch={pitch_deg:6.1f}° roll={roll_deg:6.1f}°",
             "",
         ]
         for row_cells in grid:

--- a/tests/test_outsim_orientation.py
+++ b/tests/test_outsim_orientation.py
@@ -1,0 +1,68 @@
+"""Tests for OutSim orientation calculations."""
+
+import math
+import struct
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.outsim_client import OutSimFrame
+from src.radar import RadarRenderer
+
+
+_OUTSIM_STRUCT = struct.Struct("<I3f3f3f3f3f")
+
+
+def _build_packet(
+    time_ms: int,
+    ang_vel=(0.0, 0.0, 0.0),
+    heading=(0.0, 1.0, 0.0),
+    acceleration=(0.0, 0.0, 0.0),
+    velocity=(0.0, 0.0, 0.0),
+    position=(0.0, 0.0, 0.0),
+) -> bytes:
+    """Build a binary OutSim packet matching the legacy layout."""
+
+    return _OUTSIM_STRUCT.pack(
+        time_ms,
+        *ang_vel,
+        *heading,
+        *acceleration,
+        *velocity,
+        *position,
+    )
+
+
+def test_heading_vector_converts_to_expected_yaw_pitch_roll() -> None:
+    yaw_deg_expected = 45.0
+    pitch_deg_expected = 10.0
+
+    yaw_rad = math.radians(yaw_deg_expected)
+    pitch_rad = math.radians(pitch_deg_expected)
+    cos_pitch = math.cos(pitch_rad)
+    heading = (
+        math.sin(yaw_rad) * cos_pitch,
+        math.cos(yaw_rad) * cos_pitch,
+        math.sin(pitch_rad),
+    )
+
+    packet = _build_packet(1000, heading=heading)
+    frame = OutSimFrame.from_packet(packet)
+
+    yaw_deg, pitch_deg, roll_deg = frame.yaw_pitch_roll_degrees
+
+    assert math.isclose(yaw_deg, yaw_deg_expected, abs_tol=1e-6)
+    assert math.isclose(pitch_deg, pitch_deg_expected, abs_tol=1e-6)
+    assert math.isclose(roll_deg, 0.0, abs_tol=1e-6)
+
+    renderer = RadarRenderer()
+    orientation_line = next(
+        line for line in renderer.render(frame).splitlines() if line.startswith("Orientation:")
+    )
+    expected_line = (
+        f"Orientation: yaw={yaw_deg_expected:6.1f}° pitch={pitch_deg_expected:6.1f}° roll={0.0:6.1f}°"
+    )
+    assert orientation_line == expected_line


### PR DESCRIPTION
## Summary
- add yaw/pitch/roll calculations to `OutSimFrame` while preserving the raw heading vector
- show the converted yaw/pitch/roll angles in the radar renderer output
- add a unit test covering the conversion and displayed orientation string

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f39f210d08832fa0b3751c24f2bcc4