### PR TITLE
Add project overview page

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,5 @@ functionality from the InSim/OutSim specifications as needed.
 
 | Resource | Description |
 | --- | --- |
-| [Interactive documentation site](docs/site/index.html) | Browser-based overview of the prototype with interactive summaries and deep links to common workflows. |
+| [Interactive documentation site](docs/site/index.html) | Accessible overview with navegació ràpida, enllaços interns i configuracions pas a pas del radar. |
 | [LFS manual extracts](docs/) | Official PDF guides (commands, controls, scripting, and more) that complement the interactive notes with the full simulator manuals. |

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -7,18 +7,36 @@
       name="description"
       content="Documentació del projecte LFS-Ayats: radar de telemetria ASCII per Live for Speed amb integració InSim i OutSim."
     />
+    <meta name="keywords" content="Live for Speed, LFS, InSim, OutSim, radar, telemetria" />
+    <meta property="og:title" content="Documentació · LFS-Ayats" />
+    <meta
+      property="og:description"
+      content="Explora la documentació del radar ASCII LFS-Ayats, amb passos de configuració, execució i referències tècniques."
+    />
+    <meta property="og:type" content="website" />
     <title>Documentació · LFS-Ayats</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <a class="skip-link" href="#contingut-principal">Salta al contingut principal</a>
     <header>
       <h1>LFS-Ayats</h1>
       <p>Radar de telemetria per Live for Speed amb renderitzat ASCII i integració InSim/OutSim.</p>
     </header>
 
-    <main>
-      <section id="resum">
-        <h2>Resum del projecte</h2>
+    <nav aria-label="Seccions del lloc">
+      <ul>
+        <li><a href="#resum">Resum del projecte</a></li>
+        <li><a href="#configuracio">Configuració</a></li>
+        <li><a href="#execucio">Execució</a></li>
+        <li><a href="#manuals">PDF de referència</a></li>
+        <li><a href="#tecnica">Referència tècnica</a></li>
+      </ul>
+    </nav>
+
+    <main id="contingut-principal">
+      <section id="resum" aria-labelledby="resum-titol">
+        <h2 id="resum-titol">Resum del projecte</h2>
         <p>
           LFS-Ayats és un prototip que es connecta al simulador <em>Live for Speed</em> mitjançant InSim i OutSim per
           mostrar un radar ASCII en temps real. El projecte manté el comportament original del prototip, tot
@@ -31,8 +49,8 @@
         </ul>
       </section>
 
-      <section id="configuracio">
-        <h2>Configuració</h2>
+      <section id="configuracio" aria-labelledby="configuracio-titol">
+        <h2 id="configuracio-titol">Configuració</h2>
         <p>
           Totes les opcions s&rsquo;editen a <code>config.json</code>. A continuació tens l&rsquo;estructura bàsica i els camps més
           rellevants per adaptar el radar al teu servidor de LFS:
@@ -60,29 +78,29 @@
         </p>
       </section>
 
-      <section id="execucio">
-        <h2>Com executar-ho</h2>
+      <section id="execucio" aria-labelledby="execucio-titol">
+        <h2 id="execucio-titol">Com executar-ho</h2>
         <p>Amb la configuració preparada i Live for Speed apuntant al teu equip, llança l&rsquo;aplicació així:</p>
         <pre><code>python main.py</code></pre>
         <p>Prem <kbd>Ctrl</kbd> + <kbd>C</kbd> per aturar el radar quan vulguis.</p>
       </section>
 
-      <section id="manuals">
-        <h2>Documentació en PDF</h2>
+      <section id="manuals" aria-labelledby="manuals-titol">
+        <h2 id="manuals-titol">Documentació en PDF</h2>
         <p>Consulta els manuals originals de Live for Speed per aprofundir en la configuració i protocols:</p>
         <ul>
-          <li><a href="../Category_Options - LFS Manual.pdf">Manual Category Options de Live for Speed</a></li>
-          <li><a href="../Commands - LFS Manual.pdf">Manual Commands de Live for Speed</a></li>
-          <li><a href="../Display - LFS Manual.pdf">Manual Display de Live for Speed</a></li>
-          <li><a href="../LFS Programming - LFS Manual.pdf">Manual LFS Programming de Live for Speed</a></li>
-          <li><a href="../Options_Controls - LFS Manual.pdf">Manual Options &amp; Controls de Live for Speed</a></li>
-          <li><a href="../Script Guide - LFS Manual.pdf">Manual Script Guide de Live for Speed</a></li>
-          <li><a href="../Views - LFS Manual.pdf">Manual Views de Live for Speed</a></li>
+          <li><a href="../Category_Options%20-%20LFS%20Manual.pdf">Manual Category Options de Live for Speed</a></li>
+          <li><a href="../Commands%20-%20LFS%20Manual.pdf">Manual Commands de Live for Speed</a></li>
+          <li><a href="../Display%20-%20LFS%20Manual.pdf">Manual Display de Live for Speed</a></li>
+          <li><a href="../LFS%20Programming%20-%20LFS%20Manual.pdf">Manual LFS Programming de Live for Speed</a></li>
+          <li><a href="../Options_Controls%20-%20LFS%20Manual.pdf">Manual Options &amp; Controls de Live for Speed</a></li>
+          <li><a href="../Script%20Guide%20-%20LFS%20Manual.pdf">Manual Script Guide de Live for Speed</a></li>
+          <li><a href="../Views%20-%20LFS%20Manual.pdf">Manual Views de Live for Speed</a></li>
         </ul>
       </section>
 
-      <section id="tecnica">
-        <h2>Referència tècnica</h2>
+      <section id="tecnica" aria-labelledby="tecnica-titol">
+        <h2 id="tecnica-titol">Referència tècnica</h2>
         <p>Els components principals del radar estan implementats als mòduls següents:</p>
         <ul>
           <li><a href="../../src/insim_client.py">Client InSim minimalista a src/insim_client.py</a></li>

--- a/docs/site/styles.css
+++ b/docs/site/styles.css
@@ -29,6 +29,24 @@ body {
   background: var(--color-background);
 }
 
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-accent-strong);
+  color: var(--color-surface);
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: top 0.2s ease;
+}
+
+.skip-link:focus {
+  top: 1rem;
+}
+
 body:focus-within {
   scroll-behavior: smooth;
 }
@@ -39,6 +57,30 @@ footer {
   color: var(--color-surface);
   padding: 2rem 1.5rem;
   text-align: center;
+}
+
+nav {
+  background: var(--color-surface);
+  box-shadow: var(--shadow-elevated);
+  margin: -1.5rem auto 2rem;
+  max-width: 960px;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0 0 0.75rem 0.75rem;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  color: var(--color-heading);
+  font-weight: 600;
 }
 
 main {
@@ -144,6 +186,10 @@ footer p {
 
   main {
     padding: 1.75rem 1.25rem 2.5rem;
+  }
+
+  nav {
+    margin: -1.5rem 1.25rem 2rem;
   }
 
   section {


### PR DESCRIPTION
## Summary
- add social metadata and a keyboard-accessible skip link to the documentation home page
- introduce a navigation bar with anchored shortcuts and encode PDF file links to avoid broken URLs
- restyle the page to support the new navigation and document the changes in the README

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68f4ee5c46c8832f8f1350521f98fb64