### PR TITLE
Enable clickable HUD buttons in InSim

### DIFF
--- a/src/hud.py
+++ b/src/hud.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from .insim_client import InSimClient
+from .insim_client import ISB_CLICK, InSimClient
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +66,7 @@ class HUDController:
                 top=150,
                 width=35,
                 height=6,
+                style=ISB_CLICK,
             )
             self._insim.show_button(
                 button_id=self.BEEPS_BUTTON_ID,
@@ -74,6 +75,7 @@ class HUDController:
                 top=150,
                 width=35,
                 height=6,
+                style=ISB_CLICK,
             )
         except Exception:  # pragma: no cover - defensive logging
             logger.exception("Failed to draw HUD buttons")

--- a/src/insim_client.py
+++ b/src/insim_client.py
@@ -26,6 +26,9 @@ ISP_BTN = 45
 ISP_BFN = 46
 ISP_BTC = 47
 
+# InSim button style flags
+ISB_CLICK = 1 << 2  # emits IS_BTC when the button is clicked
+
 ISF_MCI = 1 << 0  # receive multi car info packets
 ISF_CON = 1 << 1  # receive contact packets
 ISF_OBH = 1 << 2  # receive object hit packets

--- a/tests/test_insim_client.py
+++ b/tests/test_insim_client.py
@@ -6,10 +6,12 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from src.hud import HUDController  # noqa: E402
 from src.insim_client import (  # noqa: E402
+    ISP_LAP,
     ISP_NPL,
     ISP_STA,
-    ISP_LAP,
+    ISB_CLICK,
     InSimClient,
     InSimConfig,
 )
@@ -92,4 +94,26 @@ def test_lap_events_inherit_track_and_car_context() -> None:
     event = lap_events[-1]
     assert event.track == "BL1"
     assert event.car == "XFG"
+
+
+class _RecordingInSim:
+    connected = True
+
+    def __init__(self) -> None:
+        self.styles: list[int] = []
+
+    def show_button(self, *, style: int, **kwargs) -> None:
+        self.styles.append(style)
+
+    def delete_button(self, **kwargs) -> None:  # pragma: no cover - unused in test
+        pass
+
+
+def test_hud_buttons_request_clickable_style() -> None:
+    insim = _RecordingInSim()
+    controller = HUDController(insim)
+
+    controller.show(radar_enabled=True, beeps_enabled=False)
+
+    assert insim.styles == [ISB_CLICK, ISB_CLICK]
 


### PR DESCRIPTION
## Summary
- add an ISB_CLICK style flag constant to the InSim client helpers
- render HUD toggle buttons with the clickable style so LFS emits click packets
- add a regression test that asserts the HUD requests the clickable style

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f4f7306040832f8e8e01ad4bf6732e