### PR TITLE
Add hero landing section with CTA navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,12 +19,29 @@
   </head>
   <body>
     <a class="skip-link" href="#contingut-principal">Salta al contingut principal</a>
-    <header>
-      <h1>LFS-Ayats</h1>
-      <p>Radar de telemetria per Live for Speed amb renderitzat ASCII i integració InSim/OutSim.</p>
-    </header>
+    <section class="hero" aria-labelledby="hero-titol">
+      <div class="hero-inner">
+        <div class="hero-content">
+          <h1 id="hero-titol">LFS-Ayats</h1>
+          <p class="hero-subtitle">
+            Radar de telemetria en ASCII per a <em>Live for Speed</em> amb integració InSim/OutSim, pensat per oferir
+            una visió clara, configurable i en temps real de la pista.
+          </p>
+          <ul class="hero-highlights">
+            <li>Renderitzat lleuger que funciona en qualsevol terminal.</li>
+            <li>Integració directa amb els protocols oficials d&rsquo;InSim i OutSim.</li>
+            <li>Configuració senzilla amb recàrrega en calent dels paràmetres.</li>
+          </ul>
+          <div class="hero-actions">
+            <a class="cta primary" href="https://github.com/ayats-dev/LFS-Ayats">Veure repositori</a>
+            <a class="cta secondary" href="#configuracio">Guia d&rsquo;instal·lació</a>
+          </div>
+        </div>
+        <div class="hero-media" aria-hidden="true"></div>
+      </div>
+    </section>
 
-    <nav aria-label="Seccions del lloc">
+    <nav class="site-nav" aria-label="Seccions del lloc">
       <ul>
         <li><a href="#resum">Resum del projecte</a></li>
         <li><a href="#configuracio">Configuració</a></li>

--- a/styles.css
+++ b/styles.css
@@ -51,24 +51,138 @@ body:focus-within {
   scroll-behavior: smooth;
 }
 
-header,
-footer {
-  background: var(--color-heading);
+.hero {
+  background: linear-gradient(135deg, #0f172a, #1d4ed8 55%, #38bdf8);
   color: var(--color-surface);
-  padding: 2rem 1.5rem;
-  text-align: center;
+  padding: 3.5rem 1.5rem 4rem;
 }
 
-nav {
+.hero-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 3rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.hero-content {
+  flex: 1 1 540px;
+}
+
+.hero-subtitle {
+  font-size: 1.2rem;
+  max-width: 54ch;
+}
+
+.hero-highlights {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 2rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hero-highlights li {
+  position: relative;
+  padding-left: 2rem;
+  font-weight: 600;
+}
+
+.hero-highlights li::before {
+  content: "✔";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(15, 23, 42, 0.35);
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-size: 0.95rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.2);
+}
+
+.cta.primary {
+  background: var(--color-surface);
+  color: var(--color-heading);
+}
+
+.cta.secondary {
+  background: rgba(15, 23, 42, 0.3);
+  color: var(--color-surface);
+  border: 2px solid rgba(255, 255, 255, 0.4);
+}
+
+.cta:hover,
+.cta:focus {
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.cta.primary:hover,
+.cta.primary:focus {
+  background: #e2e8f0;
+}
+
+.cta.secondary:hover,
+.cta.secondary:focus {
+  background: rgba(15, 23, 42, 0.5);
+}
+
+.cta:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 3px;
+}
+
+.hero-media {
+  flex: 0 0 280px;
+  min-height: 240px;
+  border-radius: 1.5rem;
+  background: radial-gradient(circle at top right, rgba(148, 197, 255, 0.75), rgba(30, 64, 175, 0.95));
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-media::after {
+  content: "";
+  position: absolute;
+  inset: 15%;
+  border-radius: 50%;
+  border: 2px dashed rgba(255, 255, 255, 0.35);
+  opacity: 0.85;
+}
+
+.site-nav {
   background: var(--color-surface);
   box-shadow: var(--shadow-elevated);
-  margin: -1.5rem auto 2rem;
-  max-width: 960px;
-  padding: 0.75rem 1.25rem;
-  border-radius: 0 0 0.75rem 0.75rem;
+  margin: -2rem auto 3rem;
+  max-width: 1000px;
+  padding: 0.85rem 1.5rem;
+  border-radius: 0.85rem;
 }
 
-nav ul {
+.site-nav ul {
   list-style: none;
   display: flex;
   flex-wrap: wrap;
@@ -78,9 +192,16 @@ nav ul {
   padding: 0;
 }
 
-nav a {
+.site-nav a {
   color: var(--color-heading);
   font-weight: 600;
+}
+
+footer {
+  background: var(--color-heading);
+  color: var(--color-surface);
+  padding: 2rem 1.5rem;
+  text-align: center;
 }
 
 main {
@@ -179,17 +300,47 @@ footer p {
 }
 
 @media (max-width: 640px) {
-  header,
   footer {
     padding: 1.75rem 1.25rem;
+  }
+
+  .hero {
+    padding: 2.5rem 1.25rem 3rem;
+  }
+
+  .hero-inner {
+    flex-direction: column;
+    text-align: center;
+    gap: 2.5rem;
+  }
+
+  .hero-content {
+    flex: 1;
+  }
+
+  .hero-highlights li {
+    padding-left: 0;
+  }
+
+  .hero-highlights li::before {
+    display: none;
+  }
+
+  .hero-actions {
+    justify-content: center;
+  }
+
+  .hero-media {
+    width: 100%;
+    max-width: 320px;
   }
 
   main {
     padding: 1.75rem 1.25rem 2.5rem;
   }
 
-  nav {
-    margin: -1.5rem 1.25rem 2rem;
+  .site-nav {
+    margin: -2rem 1.25rem 2.5rem;
   }
 
   section {


### PR DESCRIPTION
## Summary
- replace the simple header with a hero section featuring highlights and CTA links for the repository and installation guide
- add a dedicated navigation bar following the hero to keep section anchors accessible
- update the stylesheet with gradient hero styling, CTA button treatments, and responsive tweaks

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f4f795deac832fa6887503160c9b0a