### PR TITLE
Add InSim button toggles for radar HUD and beeps

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,7 @@
+"""Core package for the LFS-Ayats telemetry prototype."""
+
+__all__ = [
+    "insim_client",
+    "radar",
+    "hud",
+]

--- a/src/hud.py
+++ b/src/hud.py
@@ -1,0 +1,97 @@
+"""ASCII HUD renderer helpers for the LFS-Ayats radar."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List
+
+from .radar import RadarController, RadarState
+
+__all__ = [
+    "HUDRenderer",
+    "HUDState",
+]
+
+
+@dataclass(frozen=True)
+class HUDState:
+    """Snapshot of what should be drawn in the ASCII HUD."""
+
+    radar_enabled: bool = True
+    beeps_enabled: bool = True
+
+
+class HUDRenderer:
+    """Render the ASCII HUD and provide button labels for the InSim client."""
+
+    def __init__(
+        self,
+        radar_controller: RadarController,
+    ) -> None:
+        self._radar_controller = radar_controller
+        self._state = HUDState(
+            radar_enabled=radar_controller.is_radar_enabled(),
+            beeps_enabled=radar_controller.are_beeps_enabled(),
+        )
+        self._redraw_listeners: List[Callable[[HUDState, str], None]] = []
+        radar_controller.subscribe(self._handle_radar_state)
+
+    # -- subscription helpers -------------------------------------------------
+    def add_redraw_listener(self, listener: Callable[[HUDState, str], None]) -> None:
+        """Register ``listener`` to be called every time the HUD is redrawn."""
+
+        if listener in self._redraw_listeners:
+            return
+        self._redraw_listeners.append(listener)
+
+    def remove_redraw_listener(
+        self, listener: Callable[[HUDState, str], None]
+    ) -> None:
+        """Remove ``listener`` from the redraw notification list."""
+
+        try:
+            self._redraw_listeners.remove(listener)
+        except ValueError:
+            pass
+
+    # -- state handling -------------------------------------------------------
+    def _handle_radar_state(self, state: RadarState) -> None:
+        self._state = HUDState(
+            radar_enabled=state.radar_enabled,
+            beeps_enabled=state.beeps_enabled,
+        )
+        self.redraw()
+
+    @property
+    def state(self) -> HUDState:
+        return self._state
+
+    # -- rendering ------------------------------------------------------------
+    def redraw(self) -> str:
+        """Return the ASCII HUD representation and notify listeners."""
+
+        ascii_hud = self.render()
+        for listener in list(self._redraw_listeners):
+            listener(self._state, ascii_hud)
+        return ascii_hud
+
+    def render(self) -> str:
+        """Render the HUD as a multi-line ASCII string."""
+
+        status_lines = [
+            "┌────────────────────────┐",
+            f"│ Radar : {'ON ' if self._state.radar_enabled else 'OFF'} │",
+            f"│ Beeps : {'ON ' if self._state.beeps_enabled else 'OFF'} │",
+            "└────────────────────────┘",
+        ]
+        return "\n".join(status_lines)
+
+    # -- button helpers -------------------------------------------------------
+    def button_caption(self, toggle: str) -> str:
+        """Return a short caption for the requested toggle button."""
+
+        if toggle == "radar":
+            return "Radar: ON" if self._state.radar_enabled else "Radar: OFF"
+        if toggle == "beeps":
+            return "Beeps: ON" if self._state.beeps_enabled else "Beeps: OFF"
+        raise ValueError(f"Unknown toggle '{toggle}'")

--- a/src/insim_client.py
+++ b/src/insim_client.py
@@ -1,0 +1,228 @@
+"""Lightweight InSim client with runtime toggle buttons."""
+
+from __future__ import annotations
+
+import logging
+import socket
+import struct
+import threading
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from .hud import HUDRenderer
+from .radar import RadarController
+
+__all__ = ["InSimClient", "InSimConfig", "BUTTON_BEEP_ID", "BUTTON_RADAR_ID"]
+
+LOGGER = logging.getLogger(__name__)
+
+# Packet type identifiers from the InSim protocol.
+ISP_ISI = 1
+ISP_BTN = 18
+ISP_BTC = 19
+
+BUTTON_RADAR_ID = 200
+BUTTON_BEEP_ID = 201
+
+
+@dataclass
+class InSimConfig:
+    """Connection configuration for the InSim client."""
+
+    host: str = "127.0.0.1"
+    port: int = 29999
+    admin_password: str = ""
+    interval_ms: int = 100
+    prefix: bytes = b"AYTS"
+    udp_port: int = 0
+    flags: int = 0
+
+
+class InSimClient:
+    """InSim client that draws toggle buttons and keeps them in sync."""
+
+    def __init__(
+        self,
+        config: InSimConfig,
+        radar_controller: RadarController,
+        hud: HUDRenderer,
+        *,
+        on_hud_redraw: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        self._config = config
+        self._radar = radar_controller
+        self._hud = hud
+        self._hud.add_redraw_listener(self._handle_hud_redraw)
+        self._external_redraw = on_hud_redraw
+
+        self._socket: Optional[socket.socket] = None
+        self._recv_thread: Optional[threading.Thread] = None
+        self._recv_buffer = bytearray()
+        self._running = threading.Event()
+        self._lock = threading.Lock()
+
+        # Prime the HUD with the current labels.
+        self._hud.redraw()
+
+    # -- connection -----------------------------------------------------------
+    def connect(self) -> None:
+        """Connect to LFS and send the initial InSim packets."""
+
+        LOGGER.info("Connecting to InSim at %s:%s", self._config.host, self._config.port)
+        self._socket = socket.create_connection((self._config.host, self._config.port))
+        self._socket.settimeout(0.25)
+        self._running.set()
+
+        self._send(self._build_isi_packet())
+        self.draw_buttons()
+
+        self._recv_thread = threading.Thread(target=self._recv_loop, name="insim-recv", daemon=True)
+        self._recv_thread.start()
+
+    def close(self) -> None:
+        """Close the connection and stop the receive thread."""
+
+        self._running.clear()
+        if self._socket is not None:
+            try:
+                self._socket.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            self._socket.close()
+            self._socket = None
+        if self._recv_thread is not None:
+            self._recv_thread.join(timeout=0.5)
+            self._recv_thread = None
+
+    # -- HUD integration ------------------------------------------------------
+    def _handle_hud_redraw(self, _state, ascii_hud: str) -> None:
+        if self._external_redraw is not None:
+            self._external_redraw(ascii_hud)
+
+    # -- button drawing -------------------------------------------------------
+    def draw_buttons(self) -> None:
+        """(Re)draw the toggle buttons with their current state."""
+
+        self._send(self._build_button_packet(BUTTON_RADAR_ID, self._hud.button_caption("radar"), top=20))
+        self._send(self._build_button_packet(BUTTON_BEEP_ID, self._hud.button_caption("beeps"), top=24))
+
+    # -- packet builders ------------------------------------------------------
+    def _build_isi_packet(self) -> bytes:
+        """Build an :code:`IS_ISI` packet with the current configuration."""
+
+        admin = self._config.admin_password.encode("latin-1", "ignore")[:15]
+        admin = admin + b"\x00" * (16 - len(admin))
+        iname = b"LFS-Ayats"[:15]
+        iname = iname + b"\x00" * (16 - len(iname))
+        prefix = (self._config.prefix or b"")[:4]
+        prefix = prefix + b"\x00" * (4 - len(prefix))
+
+        payload = struct.pack(
+            "<BBBBHHH4s16s16s",
+            0,  # placeholder for size filled later
+            ISP_ISI,
+            0,
+            0,
+            self._config.udp_port,
+            self._config.flags,
+            self._config.interval_ms,
+            prefix,
+            admin,
+            iname,
+        )
+        size = len(payload)
+        return bytes([size]) + payload[1:]
+
+    def _build_button_packet(
+        self,
+        click_id: int,
+        caption: str,
+        *,
+        left: int = 100,
+        top: int = 20,
+        width: int = 50,
+        height: int = 12,
+        inst: int = 0,
+        bstyle: int = 0,
+        type_in: int = 0,
+    ) -> bytes:
+        """Build an :code:`IS_BTN` packet for a labelled toggle button."""
+
+        text = caption.encode("latin-1", "replace")[:239]
+        text += b"\x00"
+        header = struct.pack(
+            "<BBBBBBBBBBBB",
+            0,  # size placeholder
+            ISP_BTN,
+            0,
+            0,
+            click_id & 0xFF,
+            inst & 0xFF,
+            bstyle & 0xFF,
+            type_in & 0xFF,
+            left & 0xFF,
+            top & 0xFF,
+            width & 0xFF,
+            height & 0xFF,
+        )
+        size = len(header) + len(text)
+        return bytes([size]) + header[1:] + text
+
+    # -- network loop ---------------------------------------------------------
+    def _recv_loop(self) -> None:
+        assert self._socket is not None
+        while self._running.is_set():
+            try:
+                data = self._socket.recv(256)
+            except socket.timeout:
+                continue
+            except OSError as exc:  # connection closed
+                LOGGER.debug("InSim recv loop stopped: %s", exc)
+                break
+            if not data:
+                break
+            self._recv_buffer.extend(data)
+            self._drain_buffer()
+
+    def _drain_buffer(self) -> None:
+        while len(self._recv_buffer) >= 2:
+            size = self._recv_buffer[0]
+            if len(self._recv_buffer) < size:
+                return
+            packet = bytes(self._recv_buffer[:size])
+            del self._recv_buffer[:size]
+            self._dispatch(packet)
+
+    def _dispatch(self, packet: bytes) -> None:
+        packet_type = packet[1]
+        if packet_type == ISP_BTC:
+            self._handle_btc(packet)
+
+    # -- button event handling ------------------------------------------------
+    def _handle_btc(self, packet: bytes) -> None:
+        if len(packet) < 6:
+            return
+        click_id = packet[4]
+        if click_id == (BUTTON_RADAR_ID & 0xFF):
+            self._toggle_radar()
+        elif click_id == (BUTTON_BEEP_ID & 0xFF):
+            self._toggle_beeps()
+
+    def _toggle_radar(self) -> None:
+        new_state = not self._radar.is_radar_enabled()
+        LOGGER.info("Radar toggle requested via InSim: %s", new_state)
+        self._radar.set_radar_enabled(new_state)
+        self.draw_buttons()
+
+    def _toggle_beeps(self) -> None:
+        new_state = not self._radar.are_beeps_enabled()
+        LOGGER.info("Beeps toggle requested via InSim: %s", new_state)
+        self._radar.set_beeps_enabled(new_state)
+        self.draw_buttons()
+
+    # -- low level send -------------------------------------------------------
+    def _send(self, payload: bytes) -> None:
+        if self._socket is None:
+            raise RuntimeError("InSim connection not established")
+        with self._lock:
+            self._socket.sendall(payload)

--- a/src/radar.py
+++ b/src/radar.py
@@ -1,0 +1,167 @@
+"""Radar and audio cue coordination for the LFS-Ayats prototype.
+
+This module centralises the runtime state that decides whether the radar HUD
+and the spotter beeps are enabled.  Historically these flags were only stored in
+``config.json`` which meant changing them required editing a file and
+restarting the application.  The new InSim button workflow toggles the values
+in memory, so the radar renderer and the audio layer need to react to live
+updates instead of reading from configuration files only.
+
+The :class:`RadarController` exposes a tiny event bus that other modules can
+subscribe to.  Every state transition publishes a :class:`RadarState` object,
+allowing the HUD renderer (or any other observer) to keep an up to date view of
+what should be on screen and which sounds may play.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Callable, Iterable, List
+
+__all__ = [
+    "RadarController",
+    "RadarEventBus",
+    "RadarState",
+]
+
+
+@dataclass(frozen=True)
+class RadarState:
+    """Runtime switches that affect the ASCII HUD and the audio spotter.
+
+    Attributes
+    ----------
+    radar_enabled:
+        Whether the ASCII radar overlay should be rendered.  When ``False`` the
+        renderer is expected to clear the HUD to make room for other widgets.
+    beeps_enabled:
+        Whether the spotter should play close-proximity beeps.  Guarding the
+        sound effect here keeps the audio logic isolated from the UI layer.
+    """
+
+    radar_enabled: bool = True
+    beeps_enabled: bool = True
+
+
+class RadarEventBus:
+    """Simple multicast bus that broadcasts :class:`RadarState` updates."""
+
+    def __init__(self) -> None:
+        self._listeners: List[Callable[[RadarState], None]] = []
+
+    def subscribe(self, listener: Callable[[RadarState], None]) -> None:
+        """Register ``listener`` to be called for every state update."""
+
+        if listener in self._listeners:
+            return
+        self._listeners.append(listener)
+
+    def unsubscribe(self, listener: Callable[[RadarState], None]) -> None:
+        """Remove ``listener`` from future notifications if it was registered."""
+
+        try:
+            self._listeners.remove(listener)
+        except ValueError:
+            # Removing a listener that is not on the list is a no-op on purpose.
+            pass
+
+    # Separate method to make testing of notify easier
+    def listeners(self) -> Iterable[Callable[[RadarState], None]]:
+        """Return an iterable over the currently subscribed listeners."""
+
+        return tuple(self._listeners)
+
+    def publish(self, state: RadarState) -> None:
+        """Broadcast ``state`` to all listeners."""
+
+        for listener in list(self._listeners):
+            listener(state)
+
+
+class RadarController:
+    """Authoritative source of truth for radar and beep runtime state."""
+
+    def __init__(self, event_bus: RadarEventBus | None = None) -> None:
+        self._state = RadarState()
+        self._bus = event_bus or RadarEventBus()
+
+    # -- subscription helpers -------------------------------------------------
+    def subscribe(
+        self, listener: Callable[[RadarState], None], *, replay: bool = True
+    ) -> None:
+        """Register ``listener`` and immediately emit the current state.
+
+        Parameters
+        ----------
+        listener:
+            Callable that receives :class:`RadarState` objects.
+        replay:
+            When ``True`` (the default) the listener is immediately called with
+            the current state so new subscribers can synchronise without waiting
+            for the next toggle event.
+        """
+
+        self._bus.subscribe(listener)
+        if replay:
+            listener(self._state)
+
+    def unsubscribe(self, listener: Callable[[RadarState], None]) -> None:
+        """Remove ``listener`` from the event bus."""
+
+        self._bus.unsubscribe(listener)
+
+    # -- state accessors ------------------------------------------------------
+    @property
+    def state(self) -> RadarState:
+        """Expose the current :class:`RadarState`."""
+
+        return self._state
+
+    def is_radar_enabled(self) -> bool:
+        return self._state.radar_enabled
+
+    def are_beeps_enabled(self) -> bool:
+        return self._state.beeps_enabled
+
+    # -- mutations ------------------------------------------------------------
+    def set_radar_enabled(self, enabled: bool) -> None:
+        """Toggle the radar HUD and publish the new state."""
+
+        if enabled == self._state.radar_enabled:
+            return
+        self._update_state(replace(self._state, radar_enabled=enabled))
+
+    def set_beeps_enabled(self, enabled: bool) -> None:
+        """Toggle the audio beeps and publish the new state."""
+
+        if enabled == self._state.beeps_enabled:
+            return
+        self._update_state(replace(self._state, beeps_enabled=enabled))
+
+    def _update_state(self, state: RadarState) -> None:
+        self._state = state
+        self._bus.publish(self._state)
+
+    # -- behaviour helpers ----------------------------------------------------
+    def maybe_render_ascii(self, ascii_renderer: Callable[[], str]) -> str:
+        """Render the ASCII radar only if the feature is enabled.
+
+        ``ascii_renderer`` is called lazily, avoiding unnecessary work when the
+        radar HUD is hidden.
+        """
+
+        if not self._state.radar_enabled:
+            return ""
+        return ascii_renderer()
+
+    def play_beep(self, play_callback: Callable[[], None]) -> bool:
+        """Execute ``play_callback`` if spotter beeps are enabled.
+
+        Returns ``True`` when the callback was invoked.  The caller can use this
+        to log or drive counters during testing without talking to audio APIs.
+        """
+
+        if not self._state.beeps_enabled:
+            return False
+        play_callback()
+        return True


### PR DESCRIPTION
## Summary
- add an InSim client that connects to LFS, draws radar/beep toggle buttons and handles BTC clicks
- introduce radar and HUD controllers so runtime toggles propagate to the ASCII renderer and audio cues

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68f4fd2df938832f9c0822c2df51ad66