### PR TITLE
Add static analysis tooling configuration

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,18 @@
+[MASTER]
+# Afegim el directori `src` al camí per evitar imports relatius.
+init-hook='import sys; from pathlib import Path; sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))'
+ignore=tests,docs
+extension-pkg-whitelist=
+
+[MESSAGES CONTROL]
+# Documentem els missatges desactivats per coherència amb l'estil actual.
+disable=missing-docstring,too-few-public-methods,fixme
+
+[BASIC]
+good-names=dx,dy,dt
+
+[FORMAT]
+max-line-length=100
+
+[REPORTS]
+score=yes

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: lint lint-flake8 lint-pylint lint-mypy lint-bandit
+
+lint: lint-flake8 lint-pylint lint-mypy lint-bandit
+
+lint-flake8:
+	flake8 src tests
+
+lint-pylint:
+	pylint src
+
+lint-mypy:
+	mypy src
+
+lint-bandit:
+	bandit -c bandit.yaml -r src

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Prototype telemetry radar for Live for Speed (LFS).
 
 - Python 3.10 o superior.
 - No calen dependències externes; s’utilitza exclusivament la llibreria estàndard.
+- Dependències de desenvolupament opcionals per a analitzadors estàtics: consulteu
+  `requirements-dev.txt`.
 
 ## Configuració essencial
 
@@ -71,6 +73,34 @@ la configuració segons la teva instal·lació de LFS.
 
 - Afegiu camps addicionals a `radar.py` segons les necessitats del prototip.
 - Utilitzeu els manuals d’InSim/OutSim per incorporar nous paquets o esdeveniments.
+
+### Qualitat de codi
+
+Instal·leu les dependències de desenvolupament amb:
+
+```bash
+python -m pip install -r requirements-dev.txt
+```
+
+Les eines de qualitat estan configurades perquè apuntin al paquet principal
+(`src`) i comparteixen llindars comuns:
+
+- **Flake8**: longitud de línia màxima de 100 caràcters.
+- **Pylint**: puntuació mínima (`fail-under`) de 9.0 amb algunes regles
+  desactivades (`missing-docstring`, `too-few-public-methods`, `fixme`).
+- **Mypy**: comprovacions estrictes amb prohibició de funcions sense anotacions
+  i opcions relaxades a `tests`.
+- **Bandit**: severitat mínima `LOW` i confiança `HIGH`, permetent l’ús d’`assert`
+  (regla `B101`) justificat al prototip.
+
+Per executar totes les comprovacions d’una vegada, utilitzeu el `Makefile`:
+
+```bash
+make lint
+```
+
+També podeu invocar les eines individualment: `make lint-flake8`,
+`make lint-pylint`, `make lint-mypy` o `make lint-bandit`.
 
 ## Crèdits
 

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,12 @@
+# Configuració avançada de Bandit per a LFS-Ayats.
+# Justificació: ignorem la regla B101 (ús d'assert) perquè el prototip utilitza
+# asserts internament per validar càlculs de simulació i són acceptables.
+exclude_dirs:
+  - tests
+  - docs
+targets:
+  - src
+skips:
+  - B101
+severity: LOW
+confidence: HIGH

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,12 @@
+[mypy]
+# Establim comprovacions addicionals per mantenir la base de codi estricta.
+# Aquesta configuració complementa `pyproject.toml` amb opcions que requereixen
+# un fitxer específic per alinear-nos amb altres entorns locals.
+disallow_untyped_defs = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+no_implicit_optional = True
+
+[mypy-tests.*]
+# Les proves poden ser més flexibles; permet funcions no tipades.
+disallow_untyped_defs = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = [
+    "setuptools>=65",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.flake8]
+max-line-length = 100
+extend-ignore = ["E203"]
+exclude = ["docs", "tests/data"]
+
+[tool.pylint.main]
+py-version = "3.10"
+fail-under = 9.0
+jobs = 0
+
+[tool.pylint.messages_control]
+disable = [
+    "missing-docstring",
+    "too-few-public-methods"
+]
+
+[tool.pylint.basic]
+extension-pkg-allow-list = []
+good-names = ["dx", "dy", "dt"]
+
+[tool.mypy]
+python_version = "3.10"
+mypy_path = ["src"]
+files = ["src"]
+warn_unused_configs = true
+warn_return_any = true
+ignore_missing_imports = true
+
+[tool.bandit]
+targets = ["src"]
+exclude_dirs = ["tests", "docs"]
+severity = "LOW"
+confidence = "HIGH"
+skip = ["B101"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+bandit>=1.7
+flake8>=6.1
+mypy>=1.5
+pylint>=3.0


### PR DESCRIPTION
## Summary
- add pyproject sections for flake8, pylint, mypy, and bandit targeting the src package
- introduce dedicated configuration files for mypy, pylint, and bandit with documented rule relaxations
- provide development requirements, make targets, and README guidance for running the static analysis suite

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f501d677d4832f8ebbd6a344d40823