### PR TITLE
Configure formatting tooling and add pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.pyo
+.pytest_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        additional_dependencies: []
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/PyCQA/pylint
+    rev: v3.1.0
+    hooks:
+      - id: pylint
+        args: ["--rcfile=pyproject.toml"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.9.0
+    hooks:
+      - id: mypy
+        additional_dependencies: ["types-setuptools"]
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.7
+    hooks:
+      - id: bandit
+        args: ["-c", "bandit.yaml"]

--- a/README.md
+++ b/README.md
@@ -102,6 +102,30 @@ make lint
 També podeu invocar les eines individualment: `make lint-flake8`,
 `make lint-pylint`, `make lint-mypy` o `make lint-bandit`.
 
+### Flux amb pre-commit
+
+Instal·leu [pre-commit](https://pre-commit.com) i registreu els hooks definits a
+`.pre-commit-config.yaml`:
+
+```bash
+python -m pip install pre-commit
+pre-commit install
+```
+
+Per executar totes les comprovacions manualment abans de fer `commit` utilitzeu:
+
+```bash
+pre-commit run --all-files
+```
+
+## Convencions d'estil
+
+- Les eines de formatatge (`black` i `isort`) comparteixen una longitud de línia de 100
+  caràcters i configuració compatible (`profile = black`).
+- La base de codi utilitza anotacions de tipus i es verifica amb `mypy`.
+- Les regles de `flake8`, `pylint` i `bandit` definides al projecte són part del procés de
+  revisió i s'espera que passin abans d'enviar canvis.
+
 ## Crèdits
 
 - Desenvolupament del prototip: equip LFS-Ayats.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,12 @@ exclude_dirs = ["tests", "docs"]
 severity = "LOW"
 confidence = "HIGH"
 skip = ["B101"]
+
+[tool.black]
+line-length = 100
+target-version = ["py310"]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+src_paths = ["src", "tests", "main.py"]

--- a/src/hud.py
+++ b/src/hud.py
@@ -1,4 +1,5 @@
 """Simple HUD controller for drawing toggle buttons via InSim."""
+
 from __future__ import annotations
 
 import logging

--- a/src/insim_client.py
+++ b/src/insim_client.py
@@ -1,4 +1,5 @@
 """Client utilities for working with the Live for Speed InSim interface."""
+
 from __future__ import annotations
 
 import logging
@@ -424,7 +425,9 @@ class InSimClient:
         track: Optional[str] = None
         if len(packet) >= 26:
             track_bytes = packet[20:26]
-            track = track_bytes.split(b"\x00", 1)[0].decode("ascii", errors="ignore").strip() or None
+            track = (
+                track_bytes.split(b"\x00", 1)[0].decode("ascii", errors="ignore").strip() or None
+            )
 
         if track:
             self._current_track = track
@@ -562,9 +565,7 @@ class InSimClient:
             spare=spare,
         )
 
-    def _parse_button_click_packet(
-        self, packet: bytes
-    ) -> Optional["ButtonClickEvent"]:
+    def _parse_button_click_packet(self, packet: bytes) -> Optional["ButtonClickEvent"]:
         if len(packet) < 8:
             logger.debug("Dropping incomplete IS_BTC packet: %s", packet)
             return None

--- a/src/outsim_client.py
+++ b/src/outsim_client.py
@@ -1,4 +1,5 @@
 """OutSim UDP client utilities."""
+
 from __future__ import annotations
 
 import logging
@@ -83,7 +84,13 @@ class OutSimFrame:
 class OutSimClient:
     """UDP client that yields :class:`OutSimFrame` objects."""
 
-    def __init__(self, port: int, host: str = "0.0.0.0", buffer_size: int = 256, timeout: Optional[float] = None) -> None:
+    def __init__(
+        self,
+        port: int,
+        host: str = "0.0.0.0",
+        buffer_size: int = 256,
+        timeout: Optional[float] = None,
+    ) -> None:
         self._host = host
         self._port = port
         self._buffer_size = buffer_size

--- a/src/persistence.py
+++ b/src/persistence.py
@@ -1,4 +1,5 @@
 """Telemetry persistence helpers for storing personal best lap times."""
+
 from __future__ import annotations
 
 import sqlite3
@@ -69,7 +70,9 @@ def _parse_row(row: sqlite3.Row) -> PersonalBestRecord:
     )
 
 
-def load_personal_best(track: str, car: str, *, db_path: Optional[Path] = None) -> Optional[PersonalBestRecord]:
+def load_personal_best(
+    track: str, car: str, *, db_path: Optional[Path] = None
+) -> Optional[PersonalBestRecord]:
     """Return the stored PB for the given track/car combination if it exists."""
 
     with _connect(db_path) as conn:
@@ -123,7 +126,9 @@ def record_lap(
             )
             conn.commit()
             return (
-                PersonalBestRecord(track=track, car=car, laptime_ms=int(laptime_ms), recorded_at=timestamp),
+                PersonalBestRecord(
+                    track=track, car=car, laptime_ms=int(laptime_ms), recorded_at=timestamp
+                ),
                 True,
             )
 

--- a/src/radar.py
+++ b/src/radar.py
@@ -1,4 +1,5 @@
 """ASCII radar visualisation for OutSim telemetry."""
+
 from __future__ import annotations
 
 import sys

--- a/tests/test_insim_client.py
+++ b/tests/test_insim_client.py
@@ -8,10 +8,10 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from src.hud import HUDController  # noqa: E402
 from src.insim_client import (  # noqa: E402
+    ISB_CLICK,
     ISP_LAP,
     ISP_NPL,
     ISP_STA,
-    ISB_CLICK,
     InSimClient,
     InSimConfig,
 )
@@ -116,4 +116,3 @@ def test_hud_buttons_request_clickable_style() -> None:
     controller.show(radar_enabled=True, beeps_enabled=False)
 
     assert insim.styles == [ISB_CLICK, ISB_CLICK]
-

--- a/tests/test_outsim_orientation.py
+++ b/tests/test_outsim_orientation.py
@@ -12,7 +12,6 @@ if str(PROJECT_ROOT) not in sys.path:
 from src.outsim_client import OutSimFrame
 from src.radar import RadarRenderer
 
-
 _OUTSIM_STRUCT = struct.Struct("<I3f3f3f3f3f")
 
 
@@ -62,7 +61,5 @@ def test_heading_vector_converts_to_expected_yaw_pitch_roll() -> None:
     orientation_line = next(
         line for line in renderer.render(frame).splitlines() if line.startswith("Orientation:")
     )
-    expected_line = (
-        f"Orientation: yaw={yaw_deg_expected:6.1f}° pitch={pitch_deg_expected:6.1f}° roll={0.0:6.1f}°"
-    )
+    expected_line = f"Orientation: yaw={yaw_deg_expected:6.1f}° pitch={pitch_deg_expected:6.1f}° roll={0.0:6.1f}°"
     assert orientation_line == expected_line

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from main import clear_session_timing, update_session_best
+
 from src.insim_client import LapEvent, StateEvent
 from src.outsim_client import OutSimFrame
 from src.persistence import PersonalBestRecord
@@ -282,8 +283,7 @@ def test_track_change_resets_pending_lap_start(monkeypatch) -> None:
     )
 
     FakeOutSimClient.frames_to_yield = [
-        OutSimFrame(time_ms=idx * 1000, **base_frame_kwargs)
-        for idx in range(1, 5)
+        OutSimFrame(time_ms=idx * 1000, **base_frame_kwargs) for idx in range(1, 5)
     ]
 
     try:


### PR DESCRIPTION
## Summary
- configure Black and isort in `pyproject.toml` and add a repository-wide `.gitignore`
- add a `.pre-commit-config.yaml` with hooks for formatting and static analysis
- document the pre-commit workflow and style conventions while reformatting the codebase

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f50338351c832f856c27fa2547be8a