### PR TITLE
Set up pytest configuration and shared fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ make lint
 També podeu invocar les eines individualment: `make lint-flake8`,
 `make lint-pylint`, `make lint-mypy` o `make lint-bandit`.
 
+### Tests automatitzats
+
+Els tests utilitzen `pytest` i pressuposen que el paquet s'ha instal·lat en mode
+editable perquè els imports `src.*` funcionin sense hacks de camí. Des de
+l'arrel del projecte:
+
+```bash
+python -m pip install -e .
+python -m pip install -r requirements-dev.txt  # opcional, per a eines addicionals
+pytest
+```
+
+El fitxer [`tests/conftest.py`](tests/conftest.py) conté fixtures compartides,
+com ara `insim_client_factory`, per crear instàncies d'`InSimClient` de manera
+consistent entre proves.
+
 ### Flux amb pre-commit
 
 Instal·leu [pre-commit](https://pre-commit.com) i registreu els hooks definits a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,26 @@
 [build-system]
 requires = [
-    "setuptools>=65",
+    "setuptools",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "lfs-ayats"
+version = "0.1.0"
+description = "Prototype telemetry radar for Live for Speed (LFS)."
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [
+    { name = "LFS-Ayats" }
+]
+dependencies = []
+
+[tool.setuptools]
+packages = ["src"]
+
+[tool.setuptools.package-dir]
+src = "src"
 
 [tool.flake8]
 max-line-length = 100
@@ -48,3 +65,7 @@ target-version = ["py310"]
 profile = "black"
 line_length = 100
 src_paths = ["src", "tests", "main.py"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from src.insim_client import InSimClient, InSimConfig
+
+
+@pytest.fixture()
+def insim_config() -> InSimConfig:
+    """Return a default configuration for unit tests."""
+
+    return InSimConfig(host="127.0.0.1", port=12345)
+
+
+@pytest.fixture()
+def insim_client_factory(insim_config: InSimConfig):
+    """Provide a factory that builds :class:`InSimClient` instances."""
+
+    def factory(**kwargs) -> InSimClient:
+        return InSimClient(insim_config, **kwargs)
+
+    return factory

--- a/tests/test_outsim_orientation.py
+++ b/tests/test_outsim_orientation.py
@@ -2,12 +2,6 @@
 
 import math
 import struct
-import sys
-from pathlib import Path
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
 
 from src.outsim_client import OutSimFrame
 from src.radar import RadarRenderer

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import re
 import sys
 from datetime import datetime, timezone
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from main import clear_session_timing, update_session_best
 
 from src.insim_client import LapEvent, StateEvent


### PR DESCRIPTION
## Summary
- add project metadata and pytest defaults to `pyproject.toml`
- introduce shared test fixtures and remove ad-hoc path manipulation from the suite
- document how to run pytest against the editable install in the README

## Testing
- PYTHONPATH=$PWD pytest

------
https://chatgpt.com/codex/tasks/task_e_68f504cf8028832fa896f85cea7fd149