### PR TITLE
Add CI workflow and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,134 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  quality-checks:
+    name: Quality checks (${{ matrix.python-version }} @ ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10", "3.11"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-dev.txt
+            pyproject.toml
+
+      - name: Determine pip cache directory
+        id: pip-cache-dir
+        run: echo "dir=$(python -m pip cache dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pip directory
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install -r requirements-dev.txt
+          python -m pip install black isort pytest
+
+      - name: Run black
+        run: black --check src tests main.py
+
+      - name: Run isort
+        run: isort --check-only src tests main.py
+
+      - name: Run flake8
+        run: flake8 src tests
+
+      - name: Run pylint
+        run: pylint src
+
+      - name: Run mypy
+        run: mypy src
+
+      - name: Run bandit
+        run: bandit -c bandit.yaml -r src
+
+      - name: Run pytest
+        run: pytest
+
+  static-analysis-report:
+    name: Static analysis artifact
+    runs-on: ubuntu-latest
+    needs: quality-checks
+    if: ${{ always() }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-dev.txt
+            pyproject.toml
+
+      - name: Determine pip cache directory
+        id: pip-cache-dir
+        run: echo "dir=$(python -m pip cache dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pip directory
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-pip-report-${{ hashFiles('requirements-dev.txt', 'pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-report-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install -r requirements-dev.txt
+          python -m pip install black isort pytest
+
+      - name: Generate static analysis report
+        run: |
+          set -euo pipefail
+          REPORT="static-analysis-report.txt"
+          : > "$REPORT"
+
+          run_and_log() {
+            local cmd="$1"
+            {
+              printf '\n$ %s\n' "$cmd"
+              eval "$cmd"
+            } 2>&1 | tee -a "$REPORT"
+          }
+
+          run_and_log "black --check src tests main.py"
+          run_and_log "isort --check-only src tests main.py"
+          run_and_log "flake8 src tests"
+          run_and_log "pylint src"
+          run_and_log "mypy src"
+          run_and_log "bandit -c bandit.yaml -r src"
+          run_and_log "pytest"
+
+      - name: Upload static analysis report
+        uses: actions/upload-artifact@v3
+        with:
+          name: static-analysis-report
+          path: static-analysis-report.txt
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LFS-Ayats
 
+[![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/ci.yml)
+
 Prototype telemetry radar for Live for Speed (LFS).
 
 ## Resum executiu
@@ -55,6 +57,27 @@ la configuració segons la teva instal·lació de LFS.
 - [Options_Controls - LFS Manual](docs/Options_Controls%20-%20LFS%20Manual.pdf)
 - [Views - LFS Manual](docs/Views%20-%20LFS%20Manual.pdf)
 - [Documentació interactiva](docs/site/index.html)
+
+## Integració contínua
+
+- Substituïu `OWNER/REPO` a la insignia anterior pel nom real del projecte a
+  GitHub per activar l’enllaç automàtic a la pipeline.
+- La pipeline `CI` s’executa en `push` i en `pull_request` i inclou una matriu
+  d’entorns amb `ubuntu-latest` i Python `3.10`/`3.11`.
+- Cada feina instal·la el paquet en mode editable, reutilitza la memòria cau de
+  `pip` (tant des de `actions/setup-python` com amb una memòria cau dedicada del
+  directori retornat per `python -m pip cache dir`) i després executa les
+  comprovacions següents:
+  - `black --check`
+  - `isort --check-only`
+  - `flake8`
+  - `pylint`
+  - `mypy`
+  - `bandit`
+  - `pytest`
+- Una feina addicional genera un informe consolidat amb la sortida de totes les
+  eines anteriors i l’adjunta com a artefacte (`static-analysis-report.txt`) per
+  facilitar la revisió sense haver de consultar els logs de cada feina.
 
 ## Notes per a desenvolupadors
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that runs formatting, linting, security, typing, and tests across Python 3.10/3.11 on Ubuntu
- enable pip caching and publish a combined static analysis report artifact
- document the pipeline in the README and link a status badge placeholder

## Testing
- not run (workflow definition only)


------
https://chatgpt.com/codex/tasks/task_e_68f5063d9284832fa59a2563430d4648