### PR TITLE
Align pylint configuration with .pylintrc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     rev: v3.1.0
     hooks:
       - id: pylint
-        args: ["--rcfile=pyproject.toml"]
+        args: ["--rcfile=.pylintrc"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.9.0
     hooks:

--- a/.pylintrc
+++ b/.pylintrc
@@ -3,6 +3,8 @@
 init-hook='import sys; from pathlib import Path; sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))'
 ignore=tests,docs
 extension-pkg-whitelist=
+jobs=0
+py-version=3.10
 
 [MESSAGES CONTROL]
 # Documentem els missatges desactivats per coherència amb l'estil actual.
@@ -16,3 +18,4 @@ max-line-length=100
 
 [REPORTS]
 score=yes
+fail-under=9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,21 +27,6 @@ max-line-length = 100
 extend-ignore = ["E203"]
 exclude = ["docs", "tests/data"]
 
-[tool.pylint.main]
-py-version = "3.10"
-fail-under = 9.0
-jobs = 0
-
-[tool.pylint.messages_control]
-disable = [
-    "missing-docstring",
-    "too-few-public-methods"
-]
-
-[tool.pylint.basic]
-extension-pkg-allow-list = []
-good-names = ["dx", "dy", "dt"]
-
 [tool.mypy]
 python_version = "3.10"
 mypy_path = ["src"]


### PR DESCRIPTION
## Summary
- configure the pylint pre-commit hook to load settings from .pylintrc
- consolidate pylint options inside .pylintrc and drop duplicate pyproject entries

## Testing
- pre-commit run pylint --all-files *(fails: pre-commit unavailable in environment due to installation restrictions)*
- pylint src *(fails: pylint unavailable in environment due to installation restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68f50c812af4832fbc2dc7360a8471dc