### PR TITLE
Add pytest to development requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ l'arrel del projecte:
 
 ```bash
 python -m pip install -e .
-python -m pip install -r requirements-dev.txt  # opcional, per a eines addicionals
+python -m pip install -r requirements-dev.txt  # inclou pytest i les eines de qualitat
 pytest
 ```
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,7 @@
 bandit>=1.7
+black>=23.0
 flake8>=6.1
+isort>=5.12
 mypy>=1.5
 pylint>=3.0
+pytest>=7.4


### PR DESCRIPTION
## Summary
- include pytest, black, and isort in requirements-dev so the development install provides the documented tooling
- update the README test instructions to point to the consolidated requirements file

## Testing
- python -m pip install -r requirements-dev.txt *(fails: ProxyError - tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68f50d847af8832f8a459494ce6312e7