### PR TITLE
Add source filtering support to OutSim client

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ principals:
 | `insim.host`, `insim.port` | Destinació del servidor InSim i interval (`insim.interval_ms`) per als paquets de control. |
 | `insim.admin_password` | Contrasenya opcional per autenticar la sessió InSim. |
 | `outsim.port`, `outsim.update_hz` | Port UDP on LFS emet OutSim i freqüència esperada d’actualització. |
+| `outsim.allowed_sources` | Llista d’adreces IP o xarxes CIDR autoritzades a enviar paquets OutSim. Si s’omet, s’accepten totes les fonts. |
 | `sp_radar_enabled`, `sp_beeps_enabled` | Activen radar i avisos sonors en sessions d’un sol jugador. |
 | `mp_radar_enabled`, `mp_beeps_enabled` | Equivalents per a partides multijugador quan `ISS_MULTI` està actiu. |
 | `beep_mode` | Estratègia del subsistema d’avisos (actualment marcador). |

--- a/config.json
+++ b/config.json
@@ -7,7 +7,8 @@
   },
   "outsim": {
     "port": 30000,
-    "update_hz": 60
+    "update_hz": 60,
+    "allowed_sources": ["127.0.0.1"]
   },
   "sp_radar_enabled": true,
   "sp_beeps_enabled": true,


### PR DESCRIPTION
## Summary
- add an optional whitelist parameter to `OutSimClient` that filters incoming packets and logs rejected sources
- load the OutSim whitelist from configuration and forward it to the client
- document the new configuration flag and provide a default example value

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_68f51349cc48832f8c96e04af1846384