### PR TITLE
Add configurable rate limiting to OutSim client

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ principals:
 | `insim.admin_password` | Contrasenya opcional per autenticar la sessió InSim. |
 | `outsim.port`, `outsim.update_hz` | Port UDP on LFS emet OutSim i freqüència esperada d’actualització. |
 | `outsim.allowed_sources` | Llista d’adreces IP o xarxes CIDR autoritzades a enviar paquets OutSim. Si s’omet, s’accepten totes les fonts. |
+| `outsim.max_packets_per_second` | Límit opcional de paquets OutSim per segon. Els paquets que superen el llindar es descarten i s’enregistra un avís. |
 | `sp_radar_enabled`, `sp_beeps_enabled` | Activen radar i avisos sonors en sessions d’un sol jugador. |
 | `mp_radar_enabled`, `mp_beeps_enabled` | Equivalents per a partides multijugador quan `ISS_MULTI` està actiu. |
 | `beep_mode` | Estratègia del subsistema d’avisos (actualment marcador). |

--- a/config.json
+++ b/config.json
@@ -8,7 +8,8 @@
   "outsim": {
     "port": 30000,
     "update_hz": 60,
-    "allowed_sources": ["127.0.0.1"]
+    "allowed_sources": ["127.0.0.1"],
+    "max_packets_per_second": 120.0
   },
   "sp_radar_enabled": true,
   "sp_beeps_enabled": true,

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -87,7 +87,16 @@ def test_handle_lap_switches_driver_after_track_change(monkeypatch) -> None:
     class FakeOutSimClient:
         frames_to_yield: list[OutSimFrame] = []
 
-        def __init__(self, port, host="0.0.0.0", buffer_size: int = 256, timeout=None) -> None:
+        def __init__(
+            self,
+            port,
+            host="0.0.0.0",
+            buffer_size: int = 256,
+            timeout=None,
+            *,
+            allowed_sources=None,
+            max_packets_per_second=None,
+        ) -> None:
             self._frames = list(self.frames_to_yield)
 
         def __enter__(self):
@@ -229,7 +238,16 @@ def test_track_change_resets_pending_lap_start(monkeypatch) -> None:
     class FakeOutSimClient:
         frames_to_yield: list[OutSimFrame] = []
 
-        def __init__(self, port, host="0.0.0.0", buffer_size: int = 256, timeout=None) -> None:
+        def __init__(
+            self,
+            port,
+            host="0.0.0.0",
+            buffer_size: int = 256,
+            timeout=None,
+            *,
+            allowed_sources=None,
+            max_packets_per_second=None,
+        ) -> None:
             self._frames = list(self.frames_to_yield)
 
         def __enter__(self):
@@ -338,7 +356,16 @@ def test_reference_delta_without_pb_splits_uses_estimates(monkeypatch) -> None:
     class FakeOutSimClient:
         frames_to_yield: list[OutSimFrame] = []
 
-        def __init__(self, port, host="0.0.0.0", buffer_size: int = 256, timeout=None) -> None:
+        def __init__(
+            self,
+            port,
+            host="0.0.0.0",
+            buffer_size: int = 256,
+            timeout=None,
+            *,
+            allowed_sources=None,
+            max_packets_per_second=None,
+        ) -> None:
             self._frames = list(self.frames_to_yield)
 
         def __enter__(self):


### PR DESCRIPTION
## Summary
- add an optional token-bucket rate limiter to `OutSimClient` that drops packets above the configured threshold
- expose the rate-limit configuration through `AppConfig`, `config.json`, and README documentation
- update tests and client wiring to pass the optional rate limit safely

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68f514b0d140832f975b2a850f0c8ada