### PR TITLE
Improve OutSim client source validation and tests

### DIFF
--- a/src/outsim_client.py
+++ b/src/outsim_client.py
@@ -150,7 +150,7 @@ class OutSimClient:
     ) -> Tuple[Union[ipaddress.IPv4Network, ipaddress.IPv6Network], ...]:
         networks = []
         for entry in allowed_sources:
-            text = entry.strip()
+            text = str(entry).strip()
             if not text:
                 continue
             try:
@@ -158,6 +158,10 @@ class OutSimClient:
             except ValueError as exc:
                 raise ValueError(f"Invalid OutSim allowed source '{entry}': {exc}")
             networks.append(network)
+
+        if not networks:
+            raise ValueError("No valid OutSim allowed sources were provided")
+
         return tuple(networks)
 
     def start(self) -> None:

--- a/tests/test_outsim_security.py
+++ b/tests/test_outsim_security.py
@@ -109,6 +109,26 @@ def test_outsim_client_rejects_disallowed_sources(monkeypatch, caplog) -> None:
     client.close()
 
 
+def test_outsim_client_validates_allowed_source_entries() -> None:
+    """Misconfigured allowed sources raise early errors."""
+
+    with pytest.raises(ValueError, match="Invalid OutSim allowed source"):
+        OutSimClient(port=30100, allowed_sources=["this-is-not-an-ip"])
+
+    with pytest.raises(ValueError, match="No valid OutSim allowed sources"):
+        OutSimClient(port=30101, allowed_sources=["   ", "\t\n"])
+
+
+def test_outsim_client_rejects_invalid_rate_limits() -> None:
+    """Zero or negative rate limits are rejected."""
+
+    with pytest.raises(ValueError, match="rate limit must be positive"):
+        OutSimClient(port=30102, max_packets_per_second=0)
+
+    with pytest.raises(ValueError, match="rate limit must be positive"):
+        OutSimClient(port=30103, max_packets_per_second=-5)
+
+
 def test_outsim_client_enforces_packet_rate_limit(monkeypatch, caplog) -> None:
     """Packets beyond the configured rate are dropped and reported."""
 


### PR DESCRIPTION
## Summary
- harden OutSim allowed source normalization to reject misconfigured entries
- add unit tests for invalid whitelist values and packet rate limits

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68f537f0d3d0832f8fde1617d75a96a0