### PR TITLE
Fail fast on empty OutSim whitelist

### DIFF
--- a/src/outsim_client.py
+++ b/src/outsim_client.py
@@ -100,7 +100,7 @@ class OutSimClient:
     allowed_sources:
         Optional collection of IP addresses or CIDR networks that are allowed to
         feed data into the client.  When present, packets from other sources are
-        ignored.
+        ignored.  Supplying an empty collection is considered invalid.
     max_packets_per_second:
         Optional positive float that limits how many packets are accepted each
         second.  When the incoming rate exceeds the limit, packets are dropped
@@ -121,16 +121,13 @@ class OutSimClient:
         self._buffer_size = buffer_size
         self._timeout = timeout
         self._sock: Optional[socket.socket] = None
-        self._allowed_source_strings: Optional[Tuple[str, ...]] = (
-            tuple(allowed_sources) if allowed_sources else None
-        )
-        self._allowed_networks: Optional[
-            Tuple[Union[ipaddress.IPv4Network, ipaddress.IPv6Network], ...]
-        ] = (
-            self._normalise_allowed_sources(allowed_sources)
-            if allowed_sources
-            else None
-        )
+        if allowed_sources is None:
+            self._allowed_source_strings = None
+            self._allowed_networks = None
+        else:
+            sources_tuple: Tuple[str, ...] = tuple(allowed_sources)
+            self._allowed_source_strings = sources_tuple
+            self._allowed_networks = self._normalise_allowed_sources(sources_tuple)
         self._rate_limit_last_refill: float = time.monotonic()
         if max_packets_per_second is not None:
             if max_packets_per_second <= 0:

--- a/tests/test_outsim_security.py
+++ b/tests/test_outsim_security.py
@@ -119,6 +119,13 @@ def test_outsim_client_validates_allowed_source_entries() -> None:
         OutSimClient(port=30101, allowed_sources=["   ", "\t\n"])
 
 
+def test_outsim_client_rejects_empty_allowed_sources() -> None:
+    """Explicit empty whitelists should fail fast instead of disabling checks."""
+
+    with pytest.raises(ValueError, match="No valid OutSim allowed sources"):
+        OutSimClient(port=30104, allowed_sources=[])
+
+
 def test_outsim_client_rejects_invalid_rate_limits() -> None:
     """Zero or negative rate limits are rejected."""
 


### PR DESCRIPTION
## Summary
- ensure OutSimClient validates empty whitelist collections instead of disabling filtering
- document that empty allowed_sources collections are invalid and cover the regression with a dedicated test

## Testing
- PYTHONPATH=. pytest tests/test_outsim_security.py

------
https://chatgpt.com/codex/tasks/task_e_68f53a4d756c832fb964f3048760a149