### PR TITLE
Update site accent colors to purple and add refreshed logo

### DIFF
--- a/assets/lfs-logo.svg
+++ b/assets/lfs-logo.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 280" role="img" aria-labelledby="title desc">
+  <title id="title">Logotip modernitzat de LFS-Ayats</title>
+  <desc id="desc">Composició geomètrica amb detalls clàssics i colors de cotxe de carreres.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f2937" />
+      <stop offset="55%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1a1037" />
+    </linearGradient>
+    <linearGradient id="racing" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#dc2626" />
+      <stop offset="45%" stop-color="#f87171" />
+      <stop offset="100%" stop-color="#991b1b" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f5d0fe" />
+      <stop offset="50%" stop-color="#9333ea" />
+      <stop offset="100%" stop-color="#581c87" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="280" rx="32" fill="url(#bg)" />
+  <g opacity="0.28" fill="#facc15">
+    <path d="M60 60h80v12H60z" />
+    <path d="M340 208h80v12h-80z" />
+    <path d="M120 220h60v8h-60z" />
+  </g>
+  <g fill="url(#racing)">
+    <path d="M64 180c0-56 44-102 100-102h74l-32 48h-46c-28 0-52 24-52 54z" />
+    <path d="M304 78h68c40 0 72 32 72 72 0 22-10 42-26 56l-52-10c16-6 28-22 28-40 0-24-20-44-44-44h-32z" />
+  </g>
+  <g fill="url(#accent)">
+    <path d="M132 206h120l-28 36H160c-24 0-44-20-44-44s20-44 44-44h112l-28 36h-84c-6 0-12 6-12 12s6 12 12 12z" />
+    <path d="M280 206h128l-28 36H304c-24 0-44-20-44-44s20-44 44-44h118l-26 36H292c-6 0-12 6-12 12s6 12 12 12z" />
+  </g>
+  <g fill="#f8fafc">
+    <path d="M126 96l28-48h64l-28 48z" opacity="0.82" />
+    <path d="M214 96l28-48h62l-28 48z" opacity="0.68" />
+  </g>
+  <g fill="#fef2f2" opacity="0.85">
+    <circle cx="96" cy="198" r="10" />
+    <circle cx="382" cy="198" r="10" />
+  </g>
+  <text x="80" y="150" font-family="'Eurostile', 'Orbitron', 'Segoe UI', sans-serif" font-size="52" font-weight="700" letter-spacing="6" fill="#f8fafc">
+    LFS
+  </text>
+  <text x="82" y="182" font-family="'Playfair Display', 'Times New Roman', serif" font-size="34" font-weight="600" letter-spacing="8" fill="#f5d0fe">
+    AYATS
+  </text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,9 @@
             <a class="cta secondary" href="#configuracio">Guia d&rsquo;instal·lació</a>
           </div>
         </div>
-        <div class="hero-media" aria-hidden="true"></div>
+        <div class="hero-media" aria-hidden="true">
+          <img src="assets/lfs-logo.svg" alt="" role="presentation" />
+        </div>
       </div>
     </section>
 

--- a/styles.css
+++ b/styles.css
@@ -32,34 +32,34 @@
   --shadow-soft: 0 10px 25px rgba(15, 23, 42, 0.08);
 
   --color-background: #f8fafc;
-  --color-background-alt: #eef2ff;
+  --color-background-alt: #f3e8ff;
   --color-surface: #ffffff;
   --color-text: #1f2933;
   --color-heading: #0f172a;
   --color-muted: #475569;
   --color-border: rgba(15, 23, 42, 0.12);
-  --color-accent: #2563eb;
-  --color-accent-strong: #1d4ed8;
-  --color-accent-soft: rgba(37, 99, 235, 0.12);
-  --color-hero-overlay: rgba(15, 23, 42, 0.35);
-  --gradient-hero: linear-gradient(140deg, #1d4ed8, #0f172a 65%, #14b8a6);
-  --gradient-footer: linear-gradient(120deg, #0f172a, #1f2937 45%, #111827);
+  --color-accent: #9333ea;
+  --color-accent-strong: #7e22ce;
+  --color-accent-soft: rgba(147, 51, 234, 0.14);
+  --color-hero-overlay: rgba(17, 24, 39, 0.35);
+  --gradient-hero: linear-gradient(140deg, #7e22ce, #0f172a 65%, #14b8a6);
+  --gradient-footer: linear-gradient(120deg, #0f172a, #312e81 45%, #1e1037);
 }
 
 body[data-theme="dark"] {
   --color-background: #0b1120;
-  --color-background-alt: #111c34;
+  --color-background-alt: #1a1433;
   --color-surface: #111827;
   --color-text: #e2e8f0;
   --color-heading: #f8fafc;
-  --color-muted: #cbd5f5;
+  --color-muted: #d8b4fe;
   --color-border: rgba(148, 163, 184, 0.3);
-  --color-accent: #60a5fa;
-  --color-accent-strong: #3b82f6;
-  --color-accent-soft: rgba(96, 165, 250, 0.2);
+  --color-accent: #c084fc;
+  --color-accent-strong: #a855f7;
+  --color-accent-soft: rgba(192, 132, 252, 0.2);
   --color-hero-overlay: rgba(15, 23, 42, 0.55);
-  --gradient-hero: linear-gradient(140deg, #0b1226, #1e3a8a 60%, #0d9488);
-  --gradient-footer: linear-gradient(135deg, #030712, #111827 55%, #1e293b);
+  --gradient-hero: linear-gradient(140deg, #2e1065, #1e1b4b 60%, #0d9488);
+  --gradient-footer: linear-gradient(135deg, #030712, #1f1239 55%, #312e81);
   --shadow-elevated: 0 25px 45px rgba(0, 0, 0, 0.35);
   --shadow-soft: 0 18px 30px rgba(2, 6, 23, 0.4);
 }
@@ -296,10 +296,20 @@ body[data-theme="dark"] .site-header {
   flex: 0 0 280px;
   min-height: 240px;
   border-radius: 1.5rem;
-  background: radial-gradient(circle at top right, rgba(148, 197, 255, 0.75), rgba(30, 64, 175, 0.95));
+  background: radial-gradient(circle at top right, rgba(216, 180, 254, 0.75), rgba(91, 33, 182, 0.95));
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
   position: relative;
   overflow: hidden;
+  display: grid;
+  place-items: center;
+  padding: var(--space-4);
+}
+
+.hero-media img {
+  width: 100%;
+  max-width: 220px;
+  height: auto;
+  filter: drop-shadow(0 12px 24px rgba(15, 23, 42, 0.35));
 }
 
 .hero-media::after {
@@ -351,7 +361,7 @@ footer::before {
   position: absolute;
   inset: 0;
   background-image: radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.12), transparent 60%),
-    radial-gradient(circle at 80% 70%, rgba(148, 197, 255, 0.18), transparent 50%);
+    radial-gradient(circle at 80% 70%, rgba(216, 180, 254, 0.18), transparent 50%);
   opacity: 0.7;
 }
 
@@ -557,11 +567,11 @@ footer p {
 }
 
 .data-table tbody tr:nth-child(even) {
-  background: rgba(37, 99, 235, 0.08);
+  background: rgba(147, 51, 234, 0.08);
 }
 
 body[data-theme="dark"] .data-table tbody tr:nth-child(even) {
-  background: rgba(96, 165, 250, 0.12);
+  background: rgba(192, 132, 252, 0.18);
 }
 
 .decorated-list {


### PR DESCRIPTION
## Summary
- switch the documentation site's accent palette from blue to purple in both light and dark themes, updating gradients and surfaces to match
- adjust the hero media container styling to frame a featured image with the new colorway
- add a modernized LFS-Ayats logo SVG inspired by classic racing liveries and display it in the hero

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f639ebadac832fa3e887e08cf61644