### PR TITLE
Remove decorative hero image circle overlay

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -312,14 +312,7 @@ body[data-theme="dark"] .site-header {
   filter: drop-shadow(0 12px 24px rgba(15, 23, 42, 0.35));
 }
 
-.hero-media::after {
-  content: "";
-  position: absolute;
-  inset: 15%;
-  border-radius: 50%;
-  border: 2px dashed rgba(255, 255, 255, 0.35);
-  opacity: 0.85;
-}
+
 
 .site-nav {
   background: var(--color-surface);


### PR DESCRIPTION
## Summary
- remove the dashed circular overlay around the hero image so that the unwanted circle no longer appears

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f63be9e6cc832faad7b7eb7fc6756b