### PR TITLE
Remove purple gradient background from hero media

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -296,7 +296,7 @@ body[data-theme="dark"] .site-header {
   flex: 0 0 280px;
   min-height: 240px;
   border-radius: 1.5rem;
-  background: radial-gradient(circle at top right, rgba(216, 180, 254, 0.75), rgba(91, 33, 182, 0.95));
+  background: transparent;
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- replace the hero media background gradient with a transparent background to remove the purple halo behind the logo

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f7edc97830832fa0a2577ec2f6544c