### PR TITLE
Add player telemetry payload and overlay integration

### DIFF
--- a/main.py
+++ b/main.py
@@ -696,6 +696,26 @@ def main() -> None:
                     delta_ms = current_lap_ms - reference_time
                 else:
                     delta_ms = None
+
+                lap_progress: Optional[float] = None
+                if reference_time is not None and persistent_best and persistent_best.laptime_ms > 0:
+                    lap_progress = min(
+                        max(reference_time / persistent_best.laptime_ms, 0.0),
+                        1.0,
+                    )
+                elif current_lap_ms is not None:
+                    estimated_total = lap_state.get("latest_estimated_total_ms")
+                    if estimated_total and estimated_total > 0:
+                        lap_progress = min(max(current_lap_ms / estimated_total, 0.0), 1.0)
+
+                server = telemetry_server
+                if server is not None:
+                    server.update_player_lap(
+                        progress=lap_progress,
+                        current_lap_ms=current_lap_ms,
+                        reference_lap_ms=reference_time,
+                        delta_ms=delta_ms,
+                    )
                 delta_display = f"{delta_ms:+7} ms" if delta_ms is not None else "  -- ms"
                 status_line = (
                     "Current lap: "


### PR DESCRIPTION
## Summary
- extend telemetry snapshots to include a player payload with position, heading, and lap timing data
- expose a lap telemetry update API on the broadcaster and wire it from the main loop
- update the overlay to consume the player payload for radar offsets, lap progress, and delta text

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68f7ee39165c832fbc19deed95d8a3b1