### PR TITLE
Align overlay default port with config

### DIFF
--- a/overlay/index.html
+++ b/overlay/index.html
@@ -11,7 +11,7 @@
       <header class="overlay__header">
         <div class="overlay__connection">
           <label for="port">Port</label>
-          <input id="port" name="port" type="number" min="1" max="65535" value="49100" />
+          <input id="port" name="port" type="number" min="1" max="65535" value="30333" />
           <button id="connect">Connect</button>
           <span id="status" role="status">Disconnected</span>
         </div>

--- a/overlay/overlay.js
+++ b/overlay/overlay.js
@@ -515,7 +515,7 @@
 
   resizeCanvas();
 
-  // Auto-connect if the port is supplied via query string (?port=49100)
+  // Auto-connect if the port is supplied via query string (?port=30333)
   const params = new URLSearchParams(window.location.search);
   if (params.has("port")) {
     const queryPort = params.get("port");


### PR DESCRIPTION
## Summary
- update the overlay port input default to 30333 so it matches the telemetry WebSocket configuration
- refresh the overlay auto-connect comment to reference the same default port

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7f1a0b840832faeebe978b42830dd