### PR TITLE
Use dedicated hero text color token

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,7 @@
   --color-background: #f8fafc;
   --color-background-alt: #e7f6ff;
   --color-surface: #ffffff;
+  --color-hero-text: #ffffff;
   --color-text: #1f2933;
   --color-heading: #0f172a;
   --color-muted: #475569;
@@ -50,6 +51,7 @@ body[data-theme="dark"] {
   --color-background: #0b1120;
   --color-background-alt: #0e1f30;
   --color-surface: #111827;
+  --color-hero-text: #e2e8f0;
   --color-text: #e2e8f0;
   --color-heading: #f8fafc;
   --color-muted: #9dd9f2;
@@ -169,7 +171,7 @@ body[data-theme="dark"] .site-header {
 .hero {
   position: relative;
   background: var(--gradient-hero);
-  color: var(--color-surface);
+  color: var(--color-hero-text);
   padding: var(--space-7) var(--space-4) calc(var(--space-7) + var(--space-2));
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- add a hero text color custom property for light and dark themes
- update the hero section to reference the dedicated token for better contrast

## Testing
- Manual toggle between light and dark themes

------
https://chatgpt.com/codex/tasks/task_e_68f7f4c5b474832fbea83ae79deda1f2