### PR TITLE
Scale InSim telemetry coordinates for WebSocket snapshots

### DIFF
--- a/src/telemetry_ws.py
+++ b/src/telemetry_ws.py
@@ -46,7 +46,16 @@ def _outsim_to_dict(frame: OutSimFrame) -> dict:
     }
 
 
+_INSIM_DISTANCE_SCALE = 65_536.0
+_INSIM_SPEED_SCALE = 100.0
+
+
 def _car_to_dict(car: CarInfo) -> dict:
+    x = car.x / _INSIM_DISTANCE_SCALE
+    y = car.y / _INSIM_DISTANCE_SCALE
+    z = car.z / _INSIM_DISTANCE_SCALE
+    speed = car.speed / _INSIM_SPEED_SCALE
+
     return {
         "plid": car.plid,
         "node": car.node,
@@ -54,10 +63,10 @@ def _car_to_dict(car: CarInfo) -> dict:
         "position": car.position,
         "info": car.info,
         "spare": car.spare,
-        "x": car.x,
-        "y": car.y,
-        "z": car.z,
-        "speed": car.speed,
+        "x": x,
+        "y": y,
+        "z": z,
+        "speed": speed,
         "direction": car.direction,
         "heading": car.heading,
         "angular_velocity": car.angular_velocity,

--- a/tests/test_telemetry_ws.py
+++ b/tests/test_telemetry_ws.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.insim_client import CarInfo, MultiCarInfoEvent
+from src.telemetry_ws import TelemetryBroadcaster
+
+
+def test_snapshot_converts_car_coordinates_to_metres() -> None:
+    broadcaster = TelemetryBroadcaster("127.0.0.1", 8765)
+
+    car = CarInfo(
+        node=0,
+        lap=1,
+        plid=42,
+        position=3,
+        info=0,
+        x=65_536,
+        y=-131_072,
+        z=32_768,
+        speed=450,
+        direction=0,
+        heading=0,
+        angular_velocity=0,
+    )
+
+    event = MultiCarInfoEvent(cars=[car], view_plid=car.plid)
+    broadcaster.update_mci(event)
+
+    snapshot = broadcaster._build_snapshot()
+    assert snapshot is not None
+
+    payload = json.loads(json.dumps(snapshot.__dict__, separators=(",", ":")))
+    [car_payload] = payload["cars"]
+    assert car_payload["x"] == pytest.approx(1.0)
+    assert car_payload["y"] == pytest.approx(-2.0)
+    assert car_payload["z"] == pytest.approx(0.5)
+    assert car_payload["speed"] == pytest.approx(4.5)
+
+    focused = payload["focused_car"]
+    assert focused["plid"] == car.plid
+    assert focused["x"] == pytest.approx(1.0)
+    assert focused["y"] == pytest.approx(-2.0)
+    assert focused["z"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- scale car telemetry coordinates and speeds from fixed InSim units to metres before broadcasting
- add a TelemetryBroadcaster test that verifies the emitted snapshot JSON uses metre coordinates

## Testing
- PYTHONPATH=. pytest tests/test_telemetry_ws.py

------
https://chatgpt.com/codex/tasks/task_e_68f7f4cb689c832f94aed28e00758f0b