### PR TITLE
Add configurable beep subsystem with audio drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Prototype telemetry radar for Live for Speed (LFS).
 ## Requisits
 
 - Python 3.10 o superior.
-- No calen dependències externes; s’utilitza exclusivament la llibreria estàndard.
+- Dependència opcional: [`simpleaudio`](https://simpleaudio.readthedocs.io/) per reproduir
+  els avisos sonors. Si no està disponible, el controlador d’àudio passa a un mode
+  silenciós i només registra els esdeveniments.
 - Dependències de desenvolupament opcionals per a analitzadors estàtics: consulteu
   `requirements-dev.txt`.
 
@@ -38,10 +40,17 @@ principals:
 | `telemetry_ws.update_hz` | Cadència d’actualització del flux WebSocket (recomanat entre 10 i 20 Hz per superposicions). |
 | `sp_radar_enabled`, `sp_beeps_enabled` | Activen radar i avisos sonors en sessions d’un sol jugador. |
 | `mp_radar_enabled`, `mp_beeps_enabled` | Equivalents per a partides multijugador quan `ISS_MULTI` està actiu. |
-| `beep_mode` | Estratègia del subsistema d’avisos (actualment marcador). |
+| `beep.mode` | Estratègia del subsistema d’avisos sonors (`standard`, `calm`, `aggressive`). |
+| `beep.volume` | Volum normalitzat del to (0.0–1.0). |
+| `beep.base_frequency_hz` | Freqüència base del to; es multiplica en funció de la velocitat instantània. |
+| `beep.intervals_ms` | Patró cíclic amb els intervals (en mil·lisegons) entre beeps successius. |
 
 Els canvis al fitxer es detecten i s’apliquen sense reiniciar, permetent ajustar
 la configuració segons la teva instal·lació de LFS.
+
+> Nota: el subsistema d’avisos sonors intenta carregar `simpleaudio` en temps
+> d’execució. Quan no està disponible, continua funcionant en mode silenciós i
+> registra els batecs que s’haurien reproduït.
 
 ## Quick start
 

--- a/config.json
+++ b/config.json
@@ -21,5 +21,10 @@
   "sp_beeps_enabled": true,
   "mp_radar_enabled": true,
   "mp_beeps_enabled": false,
-  "beep_mode": "standard"
+  "beep": {
+    "mode": "standard",
+    "volume": 0.6,
+    "base_frequency_hz": 880.0,
+    "intervals_ms": [400, 600]
+  }
 }

--- a/src/audio/__init__.py
+++ b/src/audio/__init__.py
@@ -1,0 +1,10 @@
+"""Audio helpers for the telemetry prototype."""
+
+from .beep_driver import BeepDriver, SilentBeepDriver, SimpleAudioBeepDriver, select_beep_driver
+
+__all__ = [
+    "BeepDriver",
+    "SilentBeepDriver",
+    "SimpleAudioBeepDriver",
+    "select_beep_driver",
+]

--- a/src/audio/beep_driver.py
+++ b/src/audio/beep_driver.py
@@ -1,0 +1,122 @@
+"""Audio driver selection utilities for the beep subsystem."""
+
+from __future__ import annotations
+
+import logging
+import math
+from array import array
+from types import ModuleType
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class BeepDriver(Protocol):
+    """Minimal interface implemented by beep audio backends."""
+
+    def set_volume(self, volume: float) -> None:
+        """Update the playback volume in the range ``[0.0, 1.0]``."""
+
+    def set_enabled(self, enabled: bool) -> None:
+        """Enable or disable playback on the backend."""
+
+    def play_beep(self, frequency_hz: float, duration_ms: int) -> None:
+        """Play a tone with the requested frequency and duration."""
+
+
+def _import_simpleaudio() -> ModuleType | None:
+    try:
+        import simpleaudio  # type: ignore[import]
+    except Exception:  # pragma: no cover - defensive
+        return None
+    return simpleaudio
+
+
+class SimpleAudioBeepDriver:
+    """Play sine-wave tones using the :mod:`simpleaudio` package."""
+
+    _SAMPLE_RATE = 44100
+
+    def __init__(self, module: ModuleType | None = None) -> None:
+        if module is None:
+            module = _import_simpleaudio()
+        if module is None:
+            raise RuntimeError("simpleaudio module not available")
+        self._simpleaudio = module
+        self._volume = 0.5
+        self._enabled = False
+
+    def set_volume(self, volume: float) -> None:
+        self._volume = max(0.0, min(1.0, float(volume)))
+
+    def set_enabled(self, enabled: bool) -> None:
+        self._enabled = bool(enabled)
+
+    def play_beep(self, frequency_hz: float, duration_ms: int) -> None:
+        if not self._enabled:
+            return
+        if self._volume <= 0.0:
+            return
+        if frequency_hz <= 0 or duration_ms <= 0:
+            return
+
+        duration_seconds = min(duration_ms / 1000.0, 2.0)
+        sample_count = max(int(round(duration_seconds * self._SAMPLE_RATE)), 1)
+        amplitude = int(round(32767 * self._volume))
+        angular_velocity = 2.0 * math.pi * float(frequency_hz) / self._SAMPLE_RATE
+
+        samples = array("h", (0 for _ in range(sample_count)))
+        for index in range(sample_count):
+            samples[index] = int(round(amplitude * math.sin(angular_velocity * index)))
+
+        try:
+            self._simpleaudio.play_buffer(samples.tobytes(), 1, 2, self._SAMPLE_RATE)
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("Failed to play beep via simpleaudio")
+
+
+class SilentBeepDriver:
+    """Fallback driver that only logs the requested beeps."""
+
+    def __init__(self) -> None:
+        self._enabled = False
+        self._volume = 0.0
+
+    def set_volume(self, volume: float) -> None:
+        self._volume = max(0.0, min(1.0, float(volume)))
+
+    def set_enabled(self, enabled: bool) -> None:
+        self._enabled = bool(enabled)
+
+    def play_beep(self, frequency_hz: float, duration_ms: int) -> None:
+        if not self._enabled:
+            return
+        logger.debug(
+            "Silent beep: frequency=%sHz duration=%sms volume=%s", frequency_hz, duration_ms, self._volume
+        )
+
+
+def select_beep_driver() -> BeepDriver:
+    """Return the first usable beep driver implementation."""
+
+    module = _import_simpleaudio()
+    if module is not None:
+        try:
+            driver = SimpleAudioBeepDriver(module)
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("Failed to initialise simpleaudio beep driver; falling back")
+        else:
+            logger.info("Using simpleaudio beep driver")
+            return driver
+
+    logger.info("Using silent beep driver")
+    return SilentBeepDriver()
+
+
+__all__ = [
+    "BeepDriver",
+    "SilentBeepDriver",
+    "SimpleAudioBeepDriver",
+    "select_beep_driver",
+]

--- a/tests/test_beep.py
+++ b/tests/test_beep.py
@@ -1,0 +1,136 @@
+"""Tests for the beep configuration and audio drivers."""
+
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+
+import pytest
+
+from main import AppConfig, BeepConfig, BeepSubsystem
+from src.audio import beep_driver
+from src.outsim_client import OutSimFrame
+
+
+def _base_config_dict() -> dict:
+    return {
+        "insim": {},
+        "outsim": {},
+        "telemetry_ws": {},
+    }
+
+
+def _make_frame(time_ms: int, speed: float) -> OutSimFrame:
+    return OutSimFrame(
+        time_ms=time_ms,
+        ang_vel=(0.0, 0.0, 0.0),
+        heading=(0.0, 0.0, 0.0),
+        acceleration=(0.0, 0.0, 0.0),
+        velocity=(speed, 0.0, 0.0),
+        position=(0.0, 0.0, 0.0),
+    )
+
+
+class RecordingDriver:
+    def __init__(self) -> None:
+        self.enabled = False
+        self.volume = None
+        self.beep_calls: list[tuple[float, int]] = []
+
+    def set_volume(self, volume: float) -> None:
+        self.volume = volume
+
+    def set_enabled(self, enabled: bool) -> None:
+        self.enabled = enabled
+
+    def play_beep(self, frequency_hz: float, duration_ms: int) -> None:
+        if not self.enabled:
+            raise AssertionError("beep played while driver disabled")
+        self.beep_calls.append((frequency_hz, duration_ms))
+
+
+def test_app_config_parses_beep_section() -> None:
+    raw = _base_config_dict()
+    raw["beep"] = {
+        "mode": "aggressive",
+        "volume": 0.75,
+        "base_frequency_hz": 990.0,
+        "intervals_ms": [120, 240],
+    }
+
+    config = AppConfig.from_dict(raw)
+
+    assert config.beep == BeepConfig(
+        mode="aggressive",
+        volume=0.75,
+        base_frequency_hz=990.0,
+        intervals_ms=[120, 240],
+    )
+
+
+def test_app_config_validates_beep_fields() -> None:
+    raw = _base_config_dict()
+    raw["beep"] = {"volume": 1.5}
+
+    with pytest.raises(ValueError):
+        AppConfig.from_dict(raw)
+
+    raw = _base_config_dict()
+    raw["beep"] = {"intervals_ms": [200, 0]}
+    with pytest.raises(ValueError):
+        AppConfig.from_dict(raw)
+
+
+def test_select_beep_driver_prefers_simpleaudio(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_module = SimpleNamespace()
+
+    def fake_play_buffer(*_args, **_kwargs):
+        return None
+
+    dummy_module.play_buffer = fake_play_buffer
+    monkeypatch.setattr(beep_driver, "_import_simpleaudio", lambda: dummy_module)
+
+    driver = beep_driver.select_beep_driver()
+    assert isinstance(driver, beep_driver.SimpleAudioBeepDriver)
+
+
+def test_select_beep_driver_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(beep_driver, "_import_simpleaudio", lambda: None)
+
+    driver = beep_driver.select_beep_driver()
+    assert isinstance(driver, beep_driver.SilentBeepDriver)
+
+
+def test_beep_subsystem_process_frame() -> None:
+    config = BeepConfig(mode="standard", volume=0.5, base_frequency_hz=660.0, intervals_ms=[100, 200])
+    driver = RecordingDriver()
+    subsystem = BeepSubsystem(config, driver=driver)
+
+    subsystem.set_enabled(True)
+
+    frames = [
+        _make_frame(0, 0.0),
+        _make_frame(50, 0.0),
+        _make_frame(100, 10.0),
+        _make_frame(250, 15.0),
+        _make_frame(300, 20.0),
+        _make_frame(400, 5.0),
+    ]
+
+    for frame in frames:
+        subsystem.process_frame(frame)
+
+    assert driver.volume == pytest.approx(0.5)
+    assert len(driver.beep_calls) == 3
+
+    freq1, dur1 = driver.beep_calls[0]
+    assert dur1 == 50
+    assert math.isclose(freq1, 660.0 * (1 + 10.0 / 50.0))
+
+    freq2, dur2 = driver.beep_calls[1]
+    assert dur2 == 100
+    assert math.isclose(freq2, 660.0 * (1 + 20.0 / 50.0))
+
+    freq3, dur3 = driver.beep_calls[2]
+    assert dur3 == 50
+    assert math.isclose(freq3, 660.0 * (1 + 5.0 / 50.0))


### PR DESCRIPTION
## Summary
- introduce an audio driver module with simpleaudio and silent fallbacks for the beep subsystem
- extend application configuration to parse beep settings and drive the updated beep subsystem logic
- update documentation, sample config, and add unit tests covering parsing, driver selection, and scheduling

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68f930546e38832f8fb885cf5133db62