### PR TITLE
Add simpleaudio runtime dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Prototype telemetry radar for Live for Speed (LFS).
 ## Requisits
 
 - Python 3.10 o superior.
-- Dependència opcional: [`simpleaudio`](https://simpleaudio.readthedocs.io/) per reproduir
-  els avisos sonors. Si no està disponible, el controlador d’àudio passa a un mode
-  silenciós i només registra els esdeveniments.
+- Dependència d’execució: [`simpleaudio`](https://simpleaudio.readthedocs.io/) (>=1.0) per
+  reproduir els avisos sonors. S’instal·la automàticament amb `pip install -e .` i
+  garanteix que el subsistema d’àudio disposi dels beeps esperats.
 - Dependències de desenvolupament opcionals per a analitzadors estàtics: consulteu
   `requirements-dev.txt`.
 
@@ -49,8 +49,9 @@ Els canvis al fitxer es detecten i s’apliquen sense reiniciar, permetent ajust
 la configuració segons la teva instal·lació de LFS.
 
 > Nota: el subsistema d’avisos sonors intenta carregar `simpleaudio` en temps
-> d’execució. Quan no està disponible, continua funcionant en mode silenciós i
-> registra els batecs que s’haurien reproduït.
+> d’execució. En entorns on la dependència no es pugui inicialitzar (per exemple,
+> sessions remotes sense dispositius d’àudio), canvia automàticament a mode
+> silenciós i registra els batecs que s’haurien reproduït.
 
 ## Quick start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@ requires-python = ">=3.10"
 authors = [
     { name = "LFS-Ayats" }
 ]
-dependencies = []
+dependencies = [
+    "simpleaudio>=1.0",
+]
 
 [tool.setuptools]
 packages = ["src"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+simpleaudio>=1.0
 bandit>=1.7
 black>=23.0
 flake8>=6.1


### PR DESCRIPTION
## Summary
- declare simpleaudio>=1.0 as a runtime dependency in pyproject.toml
- mirror the runtime dependency in local development requirements
- document that simpleaudio is installed automatically with the package

## Testing
- python -m pip install -e . *(fails: network-restricted environment cannot reach PyPI proxies)*

------
https://chatgpt.com/codex/tasks/task_e_68f934b4dc68832f8483de8f47b0c745