### PR TITLE
Parse OutSim update rate and use it for socket timeout

### DIFF
--- a/tests/test_beep.py
+++ b/tests/test_beep.py
@@ -68,6 +68,15 @@ def test_app_config_parses_beep_section() -> None:
     )
 
 
+def test_app_config_surfaces_outsim_update_hz() -> None:
+    raw = _base_config_dict()
+    raw["outsim"]["update_hz"] = 25
+
+    config = AppConfig.from_dict(raw)
+
+    assert config.outsim_update_hz == pytest.approx(25.0)
+
+
 def test_app_config_validates_beep_fields() -> None:
     raw = _base_config_dict()
     raw["beep"] = {"volume": 1.5}


### PR DESCRIPTION
## Summary
- capture an optional `update_hz` value from the OutSim config and validate that it is positive
- propagate the derived socket timeout when creating `OutSimClient`
- extend the test suite to cover the new AppConfig field and the timeout behaviour

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68f944591b64832f9a602531f1154236