### PR TITLE
Handle large IS_MCI packets and add coverage

### DIFF
--- a/tests/test_insim_client.py
+++ b/tests/test_insim_client.py
@@ -434,3 +434,49 @@ def test_parse_mci_packet_returns_empty_event_when_no_cars(
 
     assert isinstance(event, MultiCarInfoEvent)
     assert event.cars == []
+
+
+def test_parse_mci_packet_handles_large_car_count(
+    insim_client_factory: Callable[..., InSimClient]
+) -> None:
+    client = insim_client_factory()
+    count = 12
+    entry_size = 28
+    packet_length = 4 + count * entry_size
+    packet = bytearray(packet_length)
+    packet[0] = packet_length & 0xFF
+    packet[1] = ISP_MCI
+    packet[2] = 0
+    packet[3] = count
+
+    for index in range(count):
+        offset = 4 + index * entry_size
+        struct.pack_into(
+            "<HHBBBBiiiHHHh",
+            packet,
+            offset,
+            index,
+            index + 10,
+            index + 1,
+            index % 255,
+            0,
+            0,
+            index * 100,
+            index * 1_000,
+            -index * 50,
+            index * 2,
+            index * 3,
+            index * 4,
+            index * 5,
+        )
+
+    event = client._parse_mci_packet(bytes(packet))
+
+    assert isinstance(event, MultiCarInfoEvent)
+    assert event.cars
+    assert len(event.cars) == count
+    last_car = event.cars[-1]
+    assert last_car.node == count - 1
+    assert last_car.lap == count - 1 + 10
+    assert last_car.plid == count
+    assert last_car.position == (count - 1) % 255


### PR DESCRIPTION
## Summary
- ensure buffer processing waits for full IS_MCI payloads that exceed the 1-byte header length
- keep MCI parsing within the protocol's 32-car limit while validating payload length
- add regression coverage for parsing multi-car packets with many entries

## Testing
- PYTHONPATH=. pytest tests/test_insim_client.py

------
https://chatgpt.com/codex/tasks/task_e_68fa8e8ce8f4832f8270f16ff414f5e2