### PR TITLE
Filter near-player radar contacts

### DIFF
--- a/src/radar.py
+++ b/src/radar.py
@@ -10,6 +10,9 @@ from typing import Iterable, List, Sequence, TextIO
 from .outsim_client import OutSimFrame
 
 
+NEAR_CONTACT_TOLERANCE = 0.5
+
+
 @dataclass(frozen=True)
 class RadarTarget:
     """Representation of a single radar contact relative to the player."""
@@ -49,6 +52,8 @@ def compute_radar_targets(
     max_range:
         Maximum detection distance in metres. Contacts beyond this radius are
         discarded. Defaults to ``140.0`` which matches the overlay renderer.
+        Contacts closer than ``NEAR_CONTACT_TOLERANCE`` metres are ignored to
+        avoid rendering jitter from overlapping with the player's position.
     """
 
     if max_range <= 0:
@@ -77,7 +82,7 @@ def compute_radar_targets(
         offset_y = other_y - player_y
         distance = math.hypot(offset_x, offset_y)
 
-        if distance > max_range or distance <= 1e-6:
+        if distance > max_range or distance <= NEAR_CONTACT_TOLERANCE:
             continue
 
         bearing_world = math.atan2(offset_x, offset_y)

--- a/tests/test_radar_targets.py
+++ b/tests/test_radar_targets.py
@@ -22,12 +22,14 @@ def test_compute_radar_targets_filters_and_sorts() -> None:
         (50.0, 0.0),
         (-1.0, -1.0),
         (0.0, 500.0),
+        (0.03, 0.04),
     ]
 
     targets = compute_radar_targets(player, heading, others, max_range=140.0)
 
     assert extract_distances(targets) == sorted(extract_distances(targets))
     assert len(targets) == 3
+    assert all(distance > 0.5 for distance in extract_distances(targets))
     assert math.isclose(targets[0].distance, math.sqrt(2), rel_tol=1e-9)
     assert math.isclose(targets[-1].distance, 50.0)
 


### PR DESCRIPTION
## Summary
- introduce a NEAR_CONTACT_TOLERANCE constant to exclude very close radar contacts
- document the new tolerance and update filtering logic in compute_radar_targets
- extend radar target tests to cover and reject near-zero offsets

## Testing
- PYTHONPATH=. pytest tests/test_radar_targets.py

------
https://chatgpt.com/codex/tasks/task_e_68fcef6a5564832fab4c8350e13731db