### PR TITLE
Normalize fuel percent calculations for lap and split packets

### DIFF
--- a/src/insim_client.py
+++ b/src/insim_client.py
@@ -937,6 +937,9 @@ class InSimClient:
         fuel_200 = packet[offset]
         offset += 1
 
+        fuel_percent = int(round(fuel_200 / 2))
+        fuel_percent = max(0, min(100, fuel_percent))
+
         remaining = size - offset
         if remaining < 2:
             logger.error(
@@ -972,7 +975,7 @@ class InSimClient:
             flags=flags,
             penalty=penalty,
             num_pit_stops=num_stops,
-            fuel_percent=fuel_200,
+            fuel_percent=fuel_percent,
             player_name=player_name,
             spare1=spare1,
             spare2=spare2,
@@ -1002,6 +1005,9 @@ class InSimClient:
         offset += 1
         fuel_200 = packet[offset]
         offset += 1
+
+        fuel_percent = int(round(fuel_200 / 2))
+        fuel_percent = max(0, min(100, fuel_percent))
 
         remaining = size - offset
         if remaining < 2:
@@ -1039,7 +1045,7 @@ class InSimClient:
             flags=flags,
             penalty=penalty,
             num_pit_stops=num_stops,
-            fuel_percent=fuel_200,
+            fuel_percent=fuel_percent,
             player_name=player_name,
             spare1=spare1,
             spare2=spare2,

--- a/tests/test_insim_client.py
+++ b/tests/test_insim_client.py
@@ -126,7 +126,7 @@ def test_lap_events_inherit_track_and_car_context(
     packet[14] = 0
     packet[15] = 0
     packet[16] = 0
-    packet[17] = 0
+    packet[17] = 200
     packet[18] = 0xAA
     packet[19] = 0xBB
     name = b"Driver\x00"
@@ -141,6 +141,7 @@ def test_lap_events_inherit_track_and_car_context(
     assert event.player_name == "Driver"
     assert event.spare1 == 0xAA
     assert event.spare2 == 0xBB
+    assert event.fuel_percent == 100
 
 
 def test_lap_packet_preserves_negative_times(
@@ -279,7 +280,7 @@ def test_split_packet_preserves_negative_times(
     packet[14] = 1
     packet[15] = 0
     packet[16] = 0
-    packet[17] = 0
+    packet[17] = 200
     packet[18] = 0
     packet[19] = 0
     name = b"Driver\x00"
@@ -293,6 +294,7 @@ def test_split_packet_preserves_negative_times(
     assert event.car == "XFG"
     assert event.split_time_ms == -1
     assert event.estimate_time_ms == -1
+    assert event.fuel_percent == 100
 
     lap_state = {"latest_estimated_total_ms": 82_000}
     estimate_before = lap_state["latest_estimated_total_ms"]


### PR DESCRIPTION
## Summary
- convert lap and split packet fuel readings to clamped percentages derived from the raw value
- update lap and split event tests to cover the new 200→100% conversion

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68fd369783f4832f9ca7a8d02d6ead66