### PR TITLE
Add persistence helper to delete personal best records

### DIFF
--- a/src/persistence.py
+++ b/src/persistence.py
@@ -9,6 +9,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator, Optional, Tuple
 
+__all__ = [
+    "PersonalBestRecord",
+    "load_personal_best",
+    "record_lap",
+    "delete_personal_best",
+]
+
 _DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 _DEFAULT_DB_PATH = _DATA_DIR / "telemetry.db"
 
@@ -133,3 +140,17 @@ def record_lap(
             )
 
         return _parse_row(existing), False
+
+
+def delete_personal_best(
+    track: str, car: str, *, db_path: Optional[Path] = None
+) -> bool:
+    """Delete a stored PB and return ``True`` if a record was removed."""
+
+    with _connect(db_path) as conn:
+        cur = conn.execute(
+            "DELETE FROM pb WHERE track = ? AND car = ?",
+            (track, car),
+        )
+        conn.commit()
+        return cur.rowcount > 0

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 
-from src.persistence import PersonalBestRecord, load_personal_best, record_lap
+from src.persistence import (
+    PersonalBestRecord,
+    delete_personal_best,
+    load_personal_best,
+    record_lap,
+)
 
 
 def test_load_returns_none_when_missing(tmp_path: Path) -> None:
@@ -42,3 +47,20 @@ def test_record_lap_creates_and_updates_pb(tmp_path: Path) -> None:
 
     loaded = load_personal_best("BL1", "XFG", db_path=db_path)
     assert loaded == faster_record
+
+
+def test_delete_personal_best_existing_record(tmp_path: Path) -> None:
+    db_path = tmp_path / "telemetry.db"
+    timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    record_lap("BL1", "XFG", 75000, timestamp=timestamp, db_path=db_path)
+
+    deleted = delete_personal_best("BL1", "XFG", db_path=db_path)
+    assert deleted is True
+    assert load_personal_best("BL1", "XFG", db_path=db_path) is None
+
+
+def test_delete_personal_best_missing_record(tmp_path: Path) -> None:
+    db_path = tmp_path / "telemetry.db"
+
+    deleted = delete_personal_best("BL1", "XFG", db_path=db_path)
+    assert deleted is False


### PR DESCRIPTION
## Summary
- add a delete_personal_best helper to remove stored PB entries
- export the helper from the persistence module
- extend persistence tests to cover deleting existing and missing records

## Testing
- PYTHONPATH=. pytest tests/test_persistence.py

------
https://chatgpt.com/codex/tasks/task_e_68fdd840b4e8832f89f44dbeef73f6eb