### PR TITLE
Fix overlay delta unit detection and add harness test

### DIFF
--- a/tests/overlay_delta_harness.js
+++ b/tests/overlay_delta_harness.js
@@ -1,0 +1,112 @@
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const overlayPath = path.resolve(__dirname, "../overlay/overlay.js");
+const overlaySource = fs.readFileSync(overlayPath, "utf8");
+
+const noop = () => {};
+const stubContext = {
+  save: noop,
+  restore: noop,
+  setTransform: noop,
+  clearRect: noop,
+  scale: noop,
+  beginPath: noop,
+  moveTo: noop,
+  lineTo: noop,
+  quadraticCurveTo: noop,
+  closePath: noop,
+  fill: noop,
+  stroke: noop,
+  arc: noop,
+  setLineDash: noop,
+  fillRect: noop,
+  fillText: noop,
+  strokeText: noop,
+  translate: noop,
+  lineWidth: 1,
+  font: "",
+  textAlign: "",
+  textBaseline: "",
+  strokeStyle: "",
+  fillStyle: "",
+};
+
+const canvas = {
+  getContext: () => stubContext,
+  getBoundingClientRect: () => ({ width: 1920, height: 1080 }),
+  addEventListener: noop,
+  width: 1920,
+  height: 1080,
+};
+
+const checkbox = { checked: true, addEventListener: noop };
+const document = {
+  getElementById(id) {
+    switch (id) {
+      case "overlay-canvas":
+        return canvas;
+      case "port":
+        return { value: "", addEventListener: noop };
+      case "connect":
+        return { addEventListener: noop };
+      case "status":
+        return { textContent: "", className: "" };
+      case "toggle-radar":
+      case "toggle-progress":
+      case "toggle-delta":
+        return checkbox;
+      default:
+        return {};
+    }
+  },
+};
+
+const windowObj = {
+  devicePixelRatio: 1,
+  addEventListener: noop,
+  removeEventListener: noop,
+  location: { search: "" },
+};
+
+global.window = windowObj;
+global.document = document;
+global.requestAnimationFrame = (cb) => {
+  cb();
+  return 1;
+};
+global.cancelAnimationFrame = noop;
+global.WebSocket = function WebSocket() {
+  throw new Error("WebSocket should not be instantiated in tests");
+};
+global.performance = { now: () => Date.now() };
+
+vm.runInThisContext(overlaySource, { filename: "overlay.js" });
+
+const helpers = window.__overlayTest;
+if (!helpers) {
+  throw new Error("overlay helpers were not registered");
+}
+
+const { parseIncoming, formatDelta } = helpers;
+
+const basePlayer = { position: { x: 0, y: 0 } };
+
+const positiveMsState = parseIncoming({
+  player: { ...basePlayer, delta_ms: 70000 },
+});
+const negativeMsState = parseIncoming({
+  player: { ...basePlayer, delta_ms: -45000 },
+});
+const secondsState = parseIncoming({
+  player: { ...basePlayer, delta: 10 },
+});
+
+const result = {
+  positive: formatDelta(positiveMsState.player.delta),
+  negative: formatDelta(negativeMsState.player.delta),
+  seconds: formatDelta(secondsState.player.delta),
+};
+
+process.stdout.write(`${JSON.stringify(result)}\n`);

--- a/tests/test_overlay_delta_rendering.py
+++ b/tests/test_overlay_delta_rendering.py
@@ -1,0 +1,14 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_overlay_delta_rendering():
+  harness = Path(__file__).with_name("overlay_delta_harness.js")
+  result = subprocess.run(["node", str(harness)], check=True, capture_output=True, text=True)
+  payload = json.loads(result.stdout.strip())
+
+  assert payload["positive"] == "+1:10.000"
+  assert payload["negative"].startswith("-")
+  assert payload["negative"].endswith("45.000")
+  assert payload["seconds"] == "+10.000"


### PR DESCRIPTION
## Summary
- update the overlay delta parser to rely on explicit millisecond fields instead of magnitude heuristics and expose helpers for testing
- ensure negative deltas show a minus sign when formatted
- add a Node-based harness and pytest wrapper that exercises millisecond delta payloads

## Testing
- PYTHONPATH=. pytest tests/test_overlay_delta_rendering.py

------
https://chatgpt.com/codex/tasks/task_e_68fe2094c088832f9aedc043c0cf978b