### PR TITLE
docs: add bilingual skeleton (EN/CA)

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,7 @@
+This PR adds a ready-to-fill documentation skeleton in both EN and CA:
+
+- docs/en: README, QuickStart, Installation, Configuration, CLI, Troubleshooting, Telemetry
+- docs/ca: README, QuickStart, Installation, Configuration, CLI, Troubleshooting, Telemetry
+- docs/assets/img: placeholder for screenshots (with naming guidance)
+
+Conventions: ISO 8601 dates, SI units (km/h, °C), and ICU placeholders in UI strings.

--- a/PR_TITLE.txt
+++ b/PR_TITLE.txt
@@ -1,0 +1,1 @@
+docs: add bilingual skeleton (EN/CA) for user docs

--- a/docs/assets/img/README.md
+++ b/docs/assets/img/README.md
@@ -1,0 +1,7 @@
+# Image Assets
+
+Place screenshots here. Name them descriptively, e.g.:
+- `settings-language-en.png` / `settings-language-ca.png`
+- `insim-connected.png`
+
+Always add alt text in the docs. Prefer matching framing for EN/CA.

--- a/docs/ca/CLI.md
+++ b/docs/ca/CLI.md
@@ -1,0 +1,18 @@
+# Referència de CLI
+
+```text
+lfs-ayats --help
+```
+
+## Flags habituals
+- `--lang <en|ca>` — forçar idioma de la UI
+- `--insim-host <host>` — host/IP d’InSim
+- `--insim-port <port>` — port d’InSim
+- `--units <si|imperial>` — tria unitats
+- `--log-level <debug|info|warn|error>`
+
+## Exemples
+```bash
+lfs-ayats --lang ca --insim-host 127.0.0.1 --insim-port 29999
+lfs-ayats --units si --log-level debug
+```

--- a/docs/ca/Configuration.md
+++ b/docs/ca/Configuration.md
@@ -1,0 +1,18 @@
+# Configuració
+
+## Idioma i locale
+- **Selector d’idioma**: anglès (per defecte) i català.
+- Fallback: anglès.
+- Persistència (cookie/localStorage).
+
+## Unitats
+- Preferides: **km/h** i **°C**.
+- Quan la font és mph/°F, la UI mostra un avís de conversió.
+
+## Fitxers i rutes
+- Ubicació del fitxer de configuració d’usuari:
+  - Windows: `%APPDATA%\LFS-Ayats\config.json`
+  - Linux: `$XDG_CONFIG_HOME/lfs-ayats/config.json` o `~/.config/lfs-ayats/config.json`
+
+## Logs
+- Nivell per defecte: info. Rotació de fitxers activada.

--- a/docs/ca/Installation.md
+++ b/docs/ca/Installation.md
@@ -1,0 +1,17 @@
+# Instal·lació
+
+## Windows
+1. Descarrega el `.zip` de la versió.
+2. Extreu a `C:\Program Files\LFS-Ayats` (o una carpeta teva).
+3. Primer inici: permet l’accés de xarxa per InSim/OutSim.
+
+## Linux
+1. Descarrega el `.tar.gz` de la versió.
+2. Extreu i fes `chmod +x` al binari.
+3. Assegura’t que els ports per defecte (29999/30000) són oberts.
+
+## Verificació
+- Inicia l’app → Estat: **Idle**
+- Inicia LFS → Connecta → Estat: **Connected**
+
+Consulta [Configuració](./Configuration.md) per locale i unitats.

--- a/docs/ca/QuickStart.md
+++ b/docs/ca/QuickStart.md
@@ -1,0 +1,21 @@
+# Quick Start
+
+> Resum per verificar que l’eina funciona de cap a cap.
+
+## Prerequisits
+- Windows 10+ o Linux x64
+- LFS (S3 o superior) instal·lat
+- Accés de xarxa als ports d’InSim/OutSim
+
+## Passos
+1. **Descarrega** l’última versió.
+2. **Executa** l’aplicació i accepta els permisos del tallafoc.
+3. **Connecta’t** a LFS:
+   - InSim: defineix host/port i prem “Connect”.
+   - Verifica que l’estat passa a **Connected**.
+4. **Obre una sessió** a LFS i fes una volta curta.
+5. **Comprova** que la telemetria s’actualitza a la UI.
+
+## Següent
+- Configura unitats i idioma a **Settings**.
+- Si alguna cosa falla, mira [Resolució d’errors](./Troubleshooting.md).

--- a/docs/ca/README.md
+++ b/docs/ca/README.md
@@ -1,6 +1,13 @@
-# Documentació (CA)
+# Documentació de LFS Ayats (CA)
 
-Punt d'entrada per al README, Quick Start i guies d'Instal·lació en català.
+Benvingut/da! Aquest és el punt d’entrada per a la documentació d’usuari i administració.  
+Fes servir els enllaços següents:
 
-- Títols en estil de frase.
-- Exemples amb zona horària definida i unitats SI.
+- **[Quick Start](./QuickStart.md)** — arrenca en minuts
+- **[Instal·lació](./Installation.md)** — instal·lació detallada per Windows/Linux
+- **[Configuració](./Configuration.md)** — idioma, unitats i fitxers
+- **[Referència de CLI](./CLI.md)** — comandes, flags i exemples
+- **[Resolució d’errors](./Troubleshooting.md)** — problemes comuns i solucions
+- **[Telemetria i protocols LFS](./Telemetry.md)** — bases d’InSim/OutSim/OutGauge
+
+> Convencions: dates en ISO 8601 (`2025-11-02`), unitats SI (km/h, °C) i puntuació pròpia del català.

--- a/docs/ca/Telemetry.md
+++ b/docs/ca/Telemetry.md
@@ -1,0 +1,9 @@
+# Telemetria i protocols LFS
+
+Aquest projecte fa servir protocols oficials de LFS:
+
+- **InSim** — control i informació de cursa
+- **OutSim** — estat de física (dinàmica del vehicle)
+- **OutGauge** — indicadors de quadre
+
+Termes com *InSim*, *OutSim*, *OutGauge*, *Hotlap*, *Split time* i *Force Feedback* es mantenen en anglès.

--- a/docs/ca/Troubleshooting.md
+++ b/docs/ca/Troubleshooting.md
@@ -1,0 +1,14 @@
+# Resolució d’errors
+
+## No es pot connectar a InSim
+- Revisa host/port i que LFS estigui en execució.
+- Tallafoc: permet entrada/sortida per a l’aplicació.
+- Prova `127.0.0.1` si tot corre a la mateixa màquina.
+
+## Sense telemetria
+- Assegura que hi ha una sessió activa a LFS (en pista).
+- Comprova l’estat “Connected” a la UI.
+- Activa logs a nivell `debug` i mira les entrades recents.
+
+## Unitats incorrectes
+- Canvia a SI a **Settings**. Refes la sessió.

--- a/docs/en/CLI.md
+++ b/docs/en/CLI.md
@@ -1,0 +1,18 @@
+# CLI Reference
+
+```text
+lfs-ayats --help
+```
+
+## Common Flags
+- `--lang <en|ca>` — override UI language
+- `--insim-host <host>` — InSim host/IP
+- `--insim-port <port>` — InSim port
+- `--units <si|imperial>` — choose units
+- `--log-level <debug|info|warn|error>`
+
+## Examples
+```bash
+lfs-ayats --lang en --insim-host 127.0.0.1 --insim-port 29999
+lfs-ayats --units si --log-level debug
+```

--- a/docs/en/Configuration.md
+++ b/docs/en/Configuration.md
@@ -1,0 +1,18 @@
+# Configuration
+
+## Language & Locale
+- **Language selector**: English (default) and Catalan.
+- Fallback: English.
+- Stored persistently (cookie/localStorage).
+
+## Units
+- Preferred: **km/h** and **°C**.
+- When source is mph/°F, the UI shows a conversion notice.
+
+## Files & Paths
+- User config file location:
+  - Windows: `%APPDATA%\LFS-Ayats\config.json`
+  - Linux: `$XDG_CONFIG_HOME/lfs-ayats/config.json` or `~/.config/lfs-ayats/config.json`
+
+## Logging
+- Log level: info (default). Log files are rotated.

--- a/docs/en/Installation.md
+++ b/docs/en/Installation.md
@@ -1,0 +1,17 @@
+# Installation
+
+## Windows
+1. Download the `.zip` release.
+2. Extract to `C:\Program Files\LFS-Ayats` (or any folder you own).
+3. First run: allow network access for InSim/OutSim.
+
+## Linux
+1. Download the `.tar.gz` release.
+2. Extract and `chmod +x` the binary.
+3. Ensure required ports are open (default: 29999/30000).
+
+## Verify
+- Start the app → Status: **Idle**
+- Start LFS → Connect → Status: **Connected**
+
+See [Configuration](./Configuration.md) for locales and units.

--- a/docs/en/QuickStart.md
+++ b/docs/en/QuickStart.md
@@ -1,0 +1,21 @@
+# Quick Start
+
+> TL;DR to verify the tool works end-to-end.
+
+## Prerequisites
+- Windows 10+ or Linux x64
+- LFS (S3 or later) installed
+- Network access to InSim/OutSim ports
+
+## Steps
+1. **Download** the latest release.
+2. **Run** the app and accept firewall prompts.
+3. **Connect** to LFS:
+   - InSim: set host/port, click “Connect”.
+   - Verify status turns **Connected**.
+4. **Open a session** in LFS and drive a short lap.
+5. **Check telemetry** updates in the UI.
+
+## Next
+- Configure units and locale in **Settings**.
+- See [Troubleshooting](./Troubleshooting.md) if anything fails.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,8 +1,13 @@
-# Documentation (EN)
+# LFS Ayats Documentation (EN)
 
-Start here for README, Quick Start, and Installation guides in English.
+Welcome! This is the entry point for the user and admin documentation.  
+Use the links below to navigate.
 
-- Keep titles in Title Case.
-- Prefer examples with UTC timestamps and SI units.
+- **[Quick Start](./QuickStart.md)** — get up and running in minutes
+- **[Installation](./Installation.md)** — detailed install for Windows/Linux
+- **[Configuration](./Configuration.md)** — settings, units, and locales
+- **[CLI Reference](./CLI.md)** — commands, flags, and examples
+- **[Troubleshooting](./Troubleshooting.md)** — common issues and fixes
+- **[Telemetry & LFS Protocols](./Telemetry.md)** — InSim/OutSim/OutGauge basics
 
-Push CI test: 2025-11-02T09:49:28.2654200+01:00
+> Conventions: dates use ISO 8601 (`2025-11-02`), SI units (km/h, °C), and `en-US` punctuation.

--- a/docs/en/Telemetry.md
+++ b/docs/en/Telemetry.md
@@ -1,0 +1,9 @@
+# Telemetry & LFS Protocols
+
+This project relies on official LFS protocols:
+
+- **InSim** — control and race information
+- **OutSim** — physics state (car dynamics)
+- **OutGauge** — dashboard-style readouts
+
+Terms such as *InSim*, *OutSim*, *OutGauge*, *Hotlap*, *Split time*, and *Force Feedback* remain in English.

--- a/docs/en/Troubleshooting.md
+++ b/docs/en/Troubleshooting.md
@@ -1,0 +1,14 @@
+# Troubleshooting
+
+## Can't connect to InSim
+- Check host/port and that LFS is running.
+- Firewall: allow inbound/outbound for the app.
+- Try `127.0.0.1` if both run on the same machine.
+
+## No telemetry data
+- Ensure a session is active in LFS (on track).
+- Check “Connected” status in the UI.
+- Enable debug logs and inspect recent entries.
+
+## Wrong units
+- Switch to SI in **Settings**. Refresh the session.


### PR DESCRIPTION
## Resum
<!-- Explica què canvia aquest PR i per què. -->

## Impacte i18n
- [ ] Afecta **docs** (`/docs/en`, `/docs/ca`)
- [ ] Afecta **UI/CLI** (`/i18n/*.json`)
- [ ] Només codi sense impacte a usuari

## Checklist i18n (obligatori)
- [ ] **Res de strings hardcoded** en codi nou (externalitzats a `/i18n`)
- [ ] Claus noves a `en-US.json` i `ca.json` (mateixa **estructura**)
- [ ] **Placeholders** idèntics entre EN/CA
- [ ] **ICU** validat (`scripts/i18n_validate_icu.py`)
- [ ] Pseudo-localització sense trencaments (`scripts/pseudo_localize.py`)
- [ ] MD lints OK (`markdownlint`) i enllaços OK
- [ ] `alex` sense alertes crítiques; `vale` sense errors
- [ ] Captures actualitzades i **alt text** afegit si aplica
- [ ] S’ha comprovat **overflow** d’UI amb textos llargs

## Notes per a revisió
<!-- Context addicional, decisions terminològiques, captures. -->
